### PR TITLE
Fix i18n second pass

### DIFF
--- a/modules/admin/mod_redshop_cpicon/language/en-GB/en-GB.mod_redshop_cpicon.ini
+++ b/modules/admin/mod_redshop_cpicon/language/en-GB/en-GB.mod_redshop_cpicon.ini
@@ -1,0 +1,6 @@
+; Package     Redshop.Backend
+; Subpackage  mod_redshop_cpicon
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_CPICON="redSHOP - Control Panel Icon"

--- a/modules/site/mod_icetabs/language/en-GB/en-GB.mod_icetabs.ini
+++ b/modules/site/mod_icetabs/language/en-GB/en-GB.mod_icetabs.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_icetabs
+; Copyright   Copyright (C) 2005 - 2013 iceTHEME.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_ICETABS="IceTabs Module"
 SELECT_GROUP="<b style="_QQ_"color:#0B55C4"_QQ_">Select Module Mode</b>"
 SELECT_THEME_DESC="Select the theme that you want to use for your module."
 SELECT_GROUP_DESC="Select Group "

--- a/modules/site/mod_redcategoryscroller/language/da-DK/da-DK.mod_redcategoryscroller.ini
+++ b/modules/site/mod_redcategoryscroller/language/da-DK/da-DK.mod_redcategoryscroller.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redcategoryscroller
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDCATEGORYSCROLLER="RedSHOP - Main Category Scroller"
 COM_REDSHOP_THUMB_IMAGE_WIDTH = "Sæt Thumb Image Width."
 COM_REDSHOP_THUMB_IMAGE_HEIGHT = "Sæt Thumb Billedhøjde."
 COM_REDSHOP_MODULE_DESC = "Viser en redSHOP Kategori Scroller."

--- a/modules/site/mod_redcategoryscroller/language/da-DK/da-DK.mod_redcategoryscroller.sys.ini
+++ b/modules/site/mod_redcategoryscroller/language/da-DK/da-DK.mod_redcategoryscroller.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDCATEGORYSCROLLER="RedSHOP Main Category Scroller"
+MOD_REDCATEGORYSCROLLER="RedSHOP - Main Category Scroller"

--- a/modules/site/mod_redcategoryscroller/language/en-GB/en-GB.mod_redcategoryscroller.ini
+++ b/modules/site/mod_redcategoryscroller/language/en-GB/en-GB.mod_redcategoryscroller.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redcategoryscroller
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDCATEGORYSCROLLER="RedSHOP - Main Category Scroller"
 COM_REDSHOP_THUMB_IMAGE_WIDTH="Set Thumb Image Width."
 COM_REDSHOP_THUMB_IMAGE_HEIGHT="Set Thumb Image Height."
 COM_REDSHOP_MODULE_DESC="Displays a RedSHOP Category Scroller."

--- a/modules/site/mod_redcategoryscroller/language/en-GB/en-GB.mod_redcategoryscroller.sys.ini
+++ b/modules/site/mod_redcategoryscroller/language/en-GB/en-GB.mod_redcategoryscroller.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDCATEGORYSCROLLER="RedSHOP Main Category Scroller"
+MOD_REDCATEGORYSCROLLER="RedSHOP - Main Category Scroller"

--- a/modules/site/mod_redfeaturedproduct/language/da-DK/da-DK.mod_redfeaturedproduct.ini
+++ b/modules/site/mod_redfeaturedproduct/language/da-DK/da-DK.mod_redfeaturedproduct.ini
@@ -1,4 +1,9 @@
-MOD_REDFEATUREDPRODUCT = "redSHOP Featuredproduct"
+; Package     Redshop.Frontend
+; Subpackage  mod_redfeaturedproduct
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDFEATUREDPRODUCT="RedSHOP - Featured Product"
 COM_REDSHOP_MODULE_DESC = "Viser en redSHOP Featured Product Scroller."
 COM_REDSHOP_MODULE_NAME = "redSHOP Featured Product"
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige over Scroller."

--- a/modules/site/mod_redfeaturedproduct/language/en-GB/en-GB.mod_redfeaturedproduct.ini
+++ b/modules/site/mod_redfeaturedproduct/language/en-GB/en-GB.mod_redfeaturedproduct.ini
@@ -1,12 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redfeaturedproduct
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redfeaturedproduct
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDFEATUREDPRODUCT="Redshop Featuredproduct"
+MOD_REDFEATUREDPRODUCT="RedSHOP - Featured Product"
 COM_REDSHOP_MODULE_DESC ="Displays a RedSHOP Featured Product Scroller."
 COM_REDSHOP_MODULE_NAME ="RedSHOP Featured Product"
 COM_REDSHOP_PRETEXT ="This text will be displayed just above the Scroller."

--- a/modules/site/mod_redfeaturedproduct/language/en-GB/en-GB.mod_redfeaturedproduct.sys.ini
+++ b/modules/site/mod_redfeaturedproduct/language/en-GB/en-GB.mod_redfeaturedproduct.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDFEATUREDPRODUCT="RedSHOP Featured Product"
+MOD_REDFEATUREDPRODUCT="RedSHOP - Featured Product"

--- a/modules/site/mod_redfeaturedproduct/language/it-IT/it-IT.mod_redfeaturedproduct.ini
+++ b/modules/site/mod_redfeaturedproduct/language/it-IT/it-IT.mod_redfeaturedproduct.ini
@@ -1,10 +1,9 @@
-# $Id: it-IT.mod_redfeaturedproduct.ini $
-# redSHOP! Italian Translation
-# Copyright (C) 2005 - 2010 Open Source Matters. All rights reserved.
-# Copyright (C) Translation 2010- 2011 Matteo Lanini
-# License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
-# Note : All ini files need to be saved as UTF-8 - No BOM
-MOD_REDFEATUREDPRODUCT = "Redshop Featuredproduct"
+; Package     Redshop.Frontend
+; Subpackage  mod_redfeaturedproduct
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDFEATUREDPRODUCT="RedSHOP - Featured Product"
 COM_REDSHOP_MODULE_DESC=RedSHOP Featured Product Scroller,  Visualizza una vetrina dei prodotti consigliati.
 COM_REDSHOP_MODULE_NAME=RedSHOP Featured Product, Vetrina dei prodotti consigliati.
 COM_REDSHOP_PRETEXT=Questo testo sarà visualizzato sopra la Scroller.

--- a/modules/site/mod_redmanufacturer/language/da-DK/da-DK.mod_redmanufacturer.ini
+++ b/modules/site/mod_redmanufacturer/language/da-DK/da-DK.mod_redmanufacturer.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redmanufacturer
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDMANUFACTURER="redSHOP - Manufacturer"
 COM_REDSHOP_MODULE_DESC = "Viser en redSHOP Producent Scroller."
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige over Scroller."
 COM_REDSHOP_PRETEXT_LBL = "Pre-tekst"
@@ -43,4 +49,3 @@ COM_REDSHOP_SHOW_PRODUCT_NAME = "Vis Producent Navn"
 COM_REDSHOP_SHOW_PRODUCT_NAME_DESC = "Vis Producent Navn"
 COM_REDSHOP_SHOW_LINKON_PRODUCT_NAME_DESC = "Vis Link på producentens navn"
 COM_REDSHOP_SHOW_LINKON_PRODUCT_NAME = "Vis link på producentens navn"
-MOD_REDMANUFACTURER = "redSHOP Producent"

--- a/modules/site/mod_redmanufacturer/language/da-DK/da-DK.mod_redmanufacturer.sys.ini
+++ b/modules/site/mod_redmanufacturer/language/da-DK/da-DK.mod_redmanufacturer.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDMANUFACTURER="redSHOP Manufacturer"
+MOD_REDMANUFACTURER="redSHOP - Manufacturer"

--- a/modules/site/mod_redmanufacturer/language/en-GB/en-GB.mod_redmanufacturer.ini
+++ b/modules/site/mod_redmanufacturer/language/en-GB/en-GB.mod_redmanufacturer.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_manufacturer
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redmanufacturer
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDMANUFACTURER="redSHOP - Manufacturer"
 COM_REDSHOP_MODULE_DESC="Displays a RedSHOP Manufacturer Scroller."
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
 COM_REDSHOP_PRETEXT_LBL="Pre-Text"
@@ -51,4 +49,3 @@ COM_REDSHOP_SHOW_PRODUCT_NAME="Show Manufacturer Name"
 COM_REDSHOP_SHOW_PRODUCT_NAME_DESC="Show Manufacturer Name"
 COM_REDSHOP_SHOW_LINKON_PRODUCT_NAME_DESC="Show Link on manufacturer Name"
 COM_REDSHOP_SHOW_LINKON_PRODUCT_NAME="Show link on manufacturer name"
-MOD_REDMANUFACTURER="Redshop Manufacturer"

--- a/modules/site/mod_redmanufacturer/language/en-GB/en-GB.mod_redmanufacturer.sys.ini
+++ b/modules/site/mod_redmanufacturer/language/en-GB/en-GB.mod_redmanufacturer.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDMANUFACTURER="redSHOP Manufacturer"
+MOD_REDMANUFACTURER="redSHOP - Manufacturer"

--- a/modules/site/mod_redmasscart/language/da-DK/da-DK.mod_redmasscart.ini
+++ b/modules/site/mod_redmasscart/language/da-DK/da-DK.mod_redmasscart.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redmasscart
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDMASSCART="redSHOP - redMASSCART"
 COM_REDSHOP_PRODUCT_NUMBER = "varenummer"
 COM_REDSHOP_PARAMMODCARTBTNTITLE = "Titel på Button"
 COM_REDSHOP_PARAMMODCARTBTNDESC = "Sæt titlen på tilføj til indkøbskurv knap af modulet"
@@ -12,7 +18,6 @@ COM_REDSHOP_PARAMMODDESCOFINPUT = "sted titlen på textarea. Hvis ikke placeret,
 COM_REDSHOP_PARAMMODINSTITLE = "instruktion"
 COM_REDSHOP_PARAMMODINSDESC = "Information at vise."
 COM_REDSHOP_PRODUCT_QUANTITY = "Produkt Mængde"
-MOD_REDMASSCART = "redSHOP Masscart"
 COM_REDSHOP_CACHING_LBL = "Caching"
 COM_REDSHOP_CACHING_DESC = "Vælg om du vil cache indholdet af dette modul"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Module Class Suffix"

--- a/modules/site/mod_redmasscart/language/da-DK/da-DK.mod_redmasscart.sys.ini
+++ b/modules/site/mod_redmasscart/language/da-DK/da-DK.mod_redmasscart.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDMASSCART="redMASSCART"
+MOD_REDMASSCART="redSHOP - redMASSCART"

--- a/modules/site/mod_redmasscart/language/en-GB/en-GB.mod_redmasscart.ini
+++ b/modules/site/mod_redmasscart/language/en-GB/en-GB.mod_redmasscart.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redmasscart
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redmasscart
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDMASSCART="redSHOP - redMASSCART"
 COM_REDSHOP_PRODUCT_NUMBER="Product Number"
 COM_REDSHOP_PARAMMODCARTBTNTITLE="Title of Button"
 COM_REDSHOP_PARAMMODCARTBTNDESC="Place title of add to cart button of module"
@@ -20,7 +18,6 @@ COM_REDSHOP_PARAMMODDESCOFINPUT="place title of textarea. if not placed , will t
 COM_REDSHOP_PARAMMODINSTITLE="Instruction"
 COM_REDSHOP_PARAMMODINSDESC="Information to display."
 COM_REDSHOP_PRODUCT_QUANTITY="Product Quantity"
-MOD_REDMASSCART="Redshop Masscart"
 COM_REDSHOP_CACHING_LBL="Caching"
 COM_REDSHOP_CACHING_DESC="Select whether to cache the content of this module"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX="Module Class Suffix"

--- a/modules/site/mod_redmasscart/language/en-GB/en-GB.mod_redmasscart.sys.ini
+++ b/modules/site/mod_redmasscart/language/en-GB/en-GB.mod_redmasscart.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDMASSCART="redMASSCART"
+MOD_REDMASSCART="redSHOP - redMASSCART"

--- a/modules/site/mod_redproducts3d/language/da-DK/da-DK.mod_redproducts3d.ini
+++ b/modules/site/mod_redproducts3d/language/da-DK/da-DK.mod_redproducts3d.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redproducts3d
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDPRODUCTS3D="redSHOP - Product 3D 360 Module"
 COM_REDSHOP_MODULE_DESC = "redSHOP Product Module"
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige over Scroller."
 COM_REDSHOP_PRETEXT_LBL = "Pre-tekst"
@@ -25,9 +31,7 @@ COM_REDSHOP_PRICE = "Pris"
 COM_REDSHOP_BTN_ADD_TO_CART = "Tilføj til indkøbskurv"
 COM_REDSHOP_THUMB_IMAGE_WIDTH = "Produkt Thumb Billedbredde"
 COM_REDSHOP_THUMB_IMAGE_HEIGHT = "Produkt Thumb Billede højde"
-MOD_REDPRODUCTS3D = "redSHOP Product3d"
 COM_REDSHOP_CATEGORY_LBL = "Kategori"
-
 COM_REDSHOP_STAGE_WIDTH = "Stage Bredde"
 COM_REDSHOP_STAGE_HEIGHT = "Stage Højde"
 COM_REDSHOP_RADIUS = "Radius"

--- a/modules/site/mod_redproducts3d/language/da-DK/da-DK.mod_redproducts3d.sys.ini
+++ b/modules/site/mod_redproducts3d/language/da-DK/da-DK.mod_redproducts3d.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDPRODUCTS3D="redSHOP Product 3D 360 Module"
+MOD_REDPRODUCTS3D="redSHOP - Product 3D 360 Module"

--- a/modules/site/mod_redproducts3d/language/en-GB/en-GB.mod_redproducts3d.ini
+++ b/modules/site/mod_redproducts3d/language/en-GB/en-GB.mod_redproducts3d.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redproducts3d
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redproducts3d
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDPRODUCTS3D="redSHOP - Product 3D 360 Module"
 COM_REDSHOP_MODULE_DESC="redSHOP Product Module"
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
 COM_REDSHOP_PRETEXT_LBL="Pre-Text"
@@ -33,9 +31,7 @@ COM_REDSHOP_PRICE="Price"
 COM_REDSHOP_BTN_ADD_TO_CART="Add to cart"
 COM_REDSHOP_THUMB_IMAGE_WIDTH="Product Thumb Image width"
 COM_REDSHOP_THUMB_IMAGE_HEIGHT="Product Thumb Image height"
-MOD_REDPRODUCTS3D="Redshop Product3d"
 COM_REDSHOP_CATEGORY_LBL="Category"
-
 COM_REDSHOP_STAGE_WIDTH="Stage Width"
 COM_REDSHOP_STAGE_HEIGHT="Stage Height"
 COM_REDSHOP_RADIUS="Radius"

--- a/modules/site/mod_redproducts3d/language/en-GB/en-GB.mod_redproducts3d.sys.ini
+++ b/modules/site/mod_redproducts3d/language/en-GB/en-GB.mod_redproducts3d.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDPRODUCTS3D="redSHOP Product 3D 360 Module"
+MOD_REDPRODUCTS3D="redSHOP - Product 3D 360 Module"

--- a/modules/site/mod_redproductscroller/language/da-DK/da-DK.mod_redproductscroller.ini
+++ b/modules/site/mod_redproductscroller/language/da-DK/da-DK.mod_redproductscroller.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redproductscroller
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDPRODUCTSCROLLER="RedSHOP - Product Scroller"
 COM_REDSHOP_MODULE_DESC = "Viser en redSHOP Product Scroller."
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige over Scroller."
 COM_REDSHOP_PRETEXT_LBL = "Pre-tekst"
@@ -69,9 +75,6 @@ COM_REDSHOP_SCROLL_BACKGROUND_COLOR_DESC = "Baggrundsfarven hex værdi attribut 
 COM_REDSHOP_BOX_WIDTH = "Bredde af display box"
 COM_REDSHOP_ADD_TO_CART = "Tilføj til Indkøbskurv"
 COM_REDSHOP_PRE_ORDER = "Pre Order"
-MOD_REDPRODUCTSCROLLER = "redSHOP Product Scroller"
-
-
 COM_REDSHOP_CLASS_SUFFIX = "Module Class Suffix"
 COM_REDSHOP_CLASS_SFX_DESC = "Et suffiks, der skal anvendes til css klasse af modulet (table.moduletable), dette giver mulighed for enkelte modul styling."
 COM_REDSHOP_MENU_SFX = "Menu Class Suffix"

--- a/modules/site/mod_redproductscroller/language/da-DK/da-DK.mod_redproductscroller.sys.ini
+++ b/modules/site/mod_redproductscroller/language/da-DK/da-DK.mod_redproductscroller.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDPRODUCTSCROLLER="RedSHOP Product Scroller"
+MOD_REDPRODUCTSCROLLER="RedSHOP - Product Scroller"

--- a/modules/site/mod_redproductscroller/language/en-GB/en-GB.mod_redproductscroller.ini
+++ b/modules/site/mod_redproductscroller/language/en-GB/en-GB.mod_redproductscroller.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redproductscroller
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redproductscroller
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDPRODUCTSCROLLER="RedSHOP - Product Scroller"
 COM_REDSHOP_MODULE_DESC="Displays a RedSHOP Product Scroller."
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
 COM_REDSHOP_PRETEXT_LBL="Pre-Text"
@@ -77,8 +75,6 @@ COM_REDSHOP_SCROLL_BACKGROUND_COLOR_DESC="The background color hex value attribu
 COM_REDSHOP_BOX_WIDTH="Width of display box"
 COM_REDSHOP_ADD_TO_CART="Add to Cart"
 COM_REDSHOP_PRE_ORDER="Pre Order"
-MOD_REDPRODUCTSCROLLER="Redshop Product Scroller"
-
 COM_REDSHOP_CLASS_SUFFIX="Module Class Suffix"
 COM_REDSHOP_CLASS_SFX_DESC="A suffix to be applied to the css class of the module (table.moduletable), this allows individual module styling."
 COM_REDSHOP_MENU_SFX="Menu Class Suffix"

--- a/modules/site/mod_redproductscroller/language/en-GB/en-GB.mod_redproductscroller.sys.ini
+++ b/modules/site/mod_redproductscroller/language/en-GB/en-GB.mod_redproductscroller.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDPRODUCTSCROLLER="RedSHOP Product Scroller"
+MOD_REDPRODUCTSCROLLER="RedSHOP - Product Scroller"

--- a/modules/site/mod_redproducttab/language/en-GB/en-GB.mod_redproducttab.ini
+++ b/modules/site/mod_redproducttab/language/en-GB/en-GB.mod_redproducttab.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redproducttab
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redproducttab
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDPRODUCTTAB="redSHOP - Product Tab Module"
 COM_REDSHOP_MODULE_DESC="redSHOP Product Tab Module"
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
 COM_REDSHOP_PRETEXT_LBL="Pre-Text"
@@ -41,7 +39,6 @@ COM_REDSHOP_NEWEST_PRODUCTS="Newest Products"
 COM_REDSHOP_LATEST_PRODUCTS="Latest Products"
 COM_REDSHOP_MOST_SOLD_PRODUCTS="Most Sold Products"
 COM_REDSHOP_SPECIAL_PRODUCTS="Special Products"
-MOD_REDPRODUCTTAB="Redshop Producttab"
 COM_REDSHOP_THUMB_IMAGE_WIDTH="Product Thumb Width"
 COM_REDSHOP_THUMB_IMAGE_HEIGHT="Product Thumb Height"
 COM_REDSHOP_ADJUST_TO_CATEGORY="Adjust To Category"

--- a/modules/site/mod_redproducttab/language/en-GB/en-GB.mod_redproducttab.sys.ini
+++ b/modules/site/mod_redproducttab/language/en-GB/en-GB.mod_redproducttab.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDPRODUCTTAB="redSHOP Product Tab Module"
+MOD_REDPRODUCTTAB="redSHOP - Product Tab Module"

--- a/modules/site/mod_redshop_cart/language/en-GB/en-GB.mod_redshop_cart.ini
+++ b/modules/site/mod_redshop_cart/language/en-GB/en-GB.mod_redshop_cart.ini
@@ -1,12 +1,9 @@
-; version 1.1.11
-; package Joomla.Site
-; subpackage mod_redshop_cart
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_cart
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDSHOP_CART="redSHOP Cart"
+MOD_REDSHOP_CART="redSHOP - Cart module"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX="Module class suffix"
 COM_REDSHOP_CART_TEXT="Your Cart"
 COM_REDSHOP_TOTAL="Total"

--- a/modules/site/mod_redshop_category_scroller/language/da-DK/da-DK.mod_redshop_category_scroller.ini
+++ b/modules/site/mod_redshop_category_scroller/language/da-DK/da-DK.mod_redshop_category_scroller.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_category_scroller
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+COM_REDSHOP_REDSHOP_CATEGORY_SCROLLER="redSHOP - Category Scroller"
 COM_REDSHOP_MODULE_DESC = "Viser en redSHOP Featured Product Scroller."
 COM_REDSHOP_MODULE_NAME = "redSHOP Featured Product"
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige over Scroller."
@@ -32,7 +38,6 @@ COM_REDSHOP_SCROLLER_HEIGHT = "Scroller højde"
 COM_REDSHOP_SHOW_IMAGE_LBL = "Vis billede"
 COM_REDSHOP_SHOW_READMORE_LBL = "Vis ReadMore"
 COM_REDSHOP_SCROLLER_WIDTH = "Scroller Bredde"
-COM_REDSHOP_REDSHOP_CATEGORY_SCROLLER = "redSHOP Kategori Scroller"
 COM_REDSHOP_DEFAULT_CATEGORY_LBL = "Standard Kategori"
 COM_REDSHOP_DEFAULT_CATEGORY_DESC = "Standard Kategori"
 MOD_REDSHOP_CATEGORY_SCROLLER = "redSHOP Kategori Scroller"

--- a/modules/site/mod_redshop_category_scroller/language/da-DK/da-DK.mod_redshop_category_scroller.sys.ini
+++ b/modules/site/mod_redshop_category_scroller/language/da-DK/da-DK.mod_redshop_category_scroller.sys.ini
@@ -3,4 +3,5 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-COM_REDSHOP_REDSHOP_CATEGORY_SCROLLER="Redshop Category Scroller"
+COM_REDSHOP_REDSHOP_CATEGORY_SCROLLER="redSHOP - Category Scroller"
+

--- a/modules/site/mod_redshop_category_scroller/language/en-GB/en-GB.mod_redshop_category_scroller.ini
+++ b/modules/site/mod_redshop_category_scroller/language/en-GB/en-GB.mod_redshop_category_scroller.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_category_scroller
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_category_scroller
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+COM_REDSHOP_REDSHOP_CATEGORY_SCROLLER="redSHOP - Category Scroller"
 COM_REDSHOP_MODULE_DESC=" Displays a RedSHOP Featured Product Scroller."
 COM_REDSHOP_MODULE_NAME=" RedSHOP Featured Product"
 COM_REDSHOP_PRETEXT=" This text will be displayed just above the Scroller."
@@ -40,7 +38,6 @@ COM_REDSHOP_SCROLLER_HEIGHT=" Scroller height"
 COM_REDSHOP_SHOW_IMAGE_LBL="Show Image"
 COM_REDSHOP_SHOW_READMORE_LBL="Show Readmore"
 COM_REDSHOP_SCROLLER_WIDTH="Scroller Width"
-COM_REDSHOP_REDSHOP_CATEGORY_SCROLLER="Redshop Category Scroller"
 COM_REDSHOP_DEFAULT_CATEGORY_LBL="Default Category"
 COM_REDSHOP_DEFAULT_CATEGORY_DESC="Default Category"
 MOD_REDSHOP_CATEGORY_SCROLLER="Redshop Category Scroller"

--- a/modules/site/mod_redshop_category_scroller/language/en-GB/en-GB.mod_redshop_category_scroller.sys.ini
+++ b/modules/site/mod_redshop_category_scroller/language/en-GB/en-GB.mod_redshop_category_scroller.sys.ini
@@ -3,4 +3,4 @@
 ; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
 ; License     GNU General Public License version 2 or later; see LICENSE
 
-COM_REDSHOP_REDSHOP_CATEGORY_SCROLLER="Redshop Category Scroller"
+COM_REDSHOP_REDSHOP_CATEGORY_SCROLLER="redSHOP - Category Scroller"

--- a/modules/site/mod_redshop_discount/language/da-DK/da-DK.mod_redshop_discount.ini
+++ b/modules/site/mod_redshop_discount/language/da-DK/da-DK.mod_redshop_discount.ini
@@ -1,2 +1,7 @@
-MOD_REDSHOP_DISCOUNT = "redSHOP Discount"
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_discount
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_DISCOUNT="RedSHOP - Discount"
 COM_REDSHOP_DISCOUNT_DETAIL = "Rabat information"

--- a/modules/site/mod_redshop_discount/language/en-GB/en-GB.mod_redshop_discount.ini
+++ b/modules/site/mod_redshop_discount/language/en-GB/en-GB.mod_redshop_discount.ini
@@ -1,11 +1,8 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_discount
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_discount
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDSHOP_DISCOUNT="RedShop Discount"
+MOD_REDSHOP_DISCOUNT="RedSHOP - Discount"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX="Module class suffix"
 COM_REDSHOP_DISCOUNT_DETAIL="Discount Detail"

--- a/modules/site/mod_redshop_lettersearch/language/da-DK/da-DK.mod_redshop_lettersearch.ini
+++ b/modules/site/mod_redshop_lettersearch/language/da-DK/da-DK.mod_redshop_lettersearch.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_lettersearch
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_LETTERSEARCH="redSHOP - Letter Search"
 COM_REDSHOP_MODULE_DESC = "redSHOP Produkt Modul"
 COM_REDSHOP_PRETEXT = "This text will be shown right løbet Scroller."
 COM_REDSHOP_PRETEXT_LBL = "Pre-tekst"
@@ -8,4 +14,3 @@ COM_REDSHOP_NUMBER_OF_COLUMNS_DESC = "Antal kolonner"
 COM_REDSHOP_SELECT_FIELDS_DESC = "Vælg Ekstra felt og brug {searched_tag​​} til din skabelon for at vise udvalgte ekstra felt værdi for bestemt produkt"
 COM_REDSHOP_SELECT_FIELDS = "Vælg felter"
 COM_REDSHOP_LETTER_SEARCH_TEMPLATE = "Letter Søg skabelon"
-MOD_REDSHOP_LETTERSEARCH = "redSHOP Lettersearch"

--- a/modules/site/mod_redshop_lettersearch/language/en-GB/en-GB.mod_redshop_lettersearch.ini
+++ b/modules/site/mod_redshop_lettersearch/language/en-GB/en-GB.mod_redshop_lettersearch.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_lettersearch
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_lettersearch
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_LETTERSEARCH="redSHOP - Letter Search"
 COM_REDSHOP_MODULE_DESC=" redSHOP Produkt Modul"
 COM_REDSHOP_PRETEXT=" Denne tekst vil blive vist lige over Scroller."
 COM_REDSHOP_PRETEXT_LBL=" Pre-Text"

--- a/modules/site/mod_redshop_login/language/da-DK/da-DK.mod_redshop_login.ini
+++ b/modules/site/mod_redshop_login/language/da-DK/da-DK.mod_redshop_login.ini
@@ -1,9 +1,9 @@
-; $ Id: en-GB.mod_login.ini 10.498 2008/07/04 00:05:36 Z ian $
-; Joomla! Projekt
-; Copyright (C) 2005 - 2008 Open Source Matters. Alle rettigheder forbeholdt.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU / GPL, se LICENSE.php
-Note: Alle ini filer skal gemmes som UTF-8 - No BOM
-MOD_REDSHOP_LOGIN = "redSHOP Log ind"
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_login
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_LOGIN="redSHOP - Log ind"
 COM_REDSHOP_CACHING_LBL = "Caching"
 COM_REDSHOP_CACHING_DESC = "Vælg om du vil cache indholdet af dette modul"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Module Class Suffix"

--- a/modules/site/mod_redshop_login/language/de-DE/de-DE.mod_redshop_login.ini
+++ b/modules/site/mod_redshop_login/language/de-DE/de-DE.mod_redshop_login.ini
@@ -1,9 +1,9 @@
-; $ Id: DE-10498 GB.mod_login.ini 2008.07.04 00.05.36 Z ian $
-; Joomla! Projekt
-; Copyright (C) 2005 bis 2008 Open Source Matters. Alle Rechte vorbehalten.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU / GPL, see LICENSE.php
-; Anmerkung: Alle INI-Dateien müssen als UTF-8 gespeichert werden - Kein BOM
-MOD_REDSHOP_LOGIN = "RedShop Login"
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_login
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_LOGIN="redSHOP - Login"
 COM_REDSHOP_CACHING_LBL = "Caching"
 COM_REDSHOP_CACHING_DESC = "Wählen Sie, ob der Inhalt dieses Moduls cache"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Module Class Suffix"

--- a/modules/site/mod_redshop_login/language/en-GB/en-GB.mod_redshop_login.ini
+++ b/modules/site/mod_redshop_login/language/en-GB/en-GB.mod_redshop_login.ini
@@ -1,12 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_login
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_login
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
-MOD_REDSHOP_LOGIN="Redshop Login"
+MOD_REDSHOP_LOGIN="redSHOP - Login"
 COM_REDSHOP_CACHING_LBL="Caching"
 COM_REDSHOP_CACHING_DESC="Select whether to cache the content of this module"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX="Module Class Suffix"

--- a/modules/site/mod_redshop_logingreeting/language/en-GB/en-GB.mod_redshop_logingreeting.ini
+++ b/modules/site/mod_redshop_logingreeting/language/en-GB/en-GB.mod_redshop_logingreeting.ini
@@ -1,0 +1,6 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_logingreeting
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_LOGINGREETING="redSHOP - login greeting"

--- a/modules/site/mod_redshop_logingreeting/mod_redshop_logingreeting.xml
+++ b/modules/site/mod_redshop_logingreeting/mod_redshop_logingreeting.xml
@@ -12,8 +12,9 @@
         <filename module="mod_redshop_logingreeting">mod_redshop_logingreeting.php</filename>
         <folder module="mod_redshop_logingreeting">css</folder>
     </files>
+    <language tag="en-GB">language/en-GB/en-GB.mod_redshop_logingreeting.ini</language>
+    <language tag="en-GB">language/en-GB/en-GB.mod_redshop_logingreeting.sys.ini</language>
     <languages>
-        <language tag="en-GB">language/en-GB/en-GB.mod_redshop_logingreeting.sys.ini</language>
     </languages>
     <config>
         <fields name="params">

--- a/modules/site/mod_redshop_newsletter/language/da-DK/da-DK.mod_redshop_newsletter.ini
+++ b/modules/site/mod_redshop_newsletter/language/da-DK/da-DK.mod_redshop_newsletter.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_newsletter
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_NEWSLETTER="redSHOP - Newsletter"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Modul class suffix"
 COM_REDSHOP_NEWSLETTER_SUBSCRIPTION = "Nyhedsbrev abonnement"
 COM_REDSHOP_SUBSCRIBE = "Abonner"
@@ -8,4 +14,3 @@ COM_REDSHOP_NEWSLETTER = "Newsletter"
 COM_REDSHOP_ENTER_AN_EMAIL_ADDRESS = "Indtast en e-mail-adresse."
 COM_REDSHOP_EMAIL_ADDRESS_NOT_VALID = "Indtast gyldig e-mail-adresse."
 COM_REDSHOP_ENTER_A_NAME = "Indtast et navn."
-MOD_REDSHOP_NEWSLETTER = "redSHOP Newsletter"

--- a/modules/site/mod_redshop_newsletter/language/en-GB/en-GB.mod_redshop_newsletter.ini
+++ b/modules/site/mod_redshop_newsletter/language/en-GB/en-GB.mod_redshop_newsletter.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_newsletter
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_newsletter
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_NEWSLETTER="redSHOP - Newsletter"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX="Module class suffix"
 COM_REDSHOP_NEWSLETTER_SUBSCRIPTION="Newsletter Subscription"
 COM_REDSHOP_SUBSCRIBE="Subscribe"
@@ -16,4 +14,3 @@ COM_REDSHOP_NEWSLETTER="Newsletter"
 COM_REDSHOP_ENTER_AN_EMAIL_ADDRESS="Enter an E-mail Address."
 COM_REDSHOP_EMAIL_ADDRESS_NOT_VALID="Enter Valid E-mail Address."
 COM_REDSHOP_ENTER_A_NAME="Enter a name."
-MOD_REDSHOP_NEWSLETTER="Redshop Newsletter"

--- a/modules/site/mod_redshop_newsletter/language/it-IT/it-IT.mod_redshop_newsletter.ini
+++ b/modules/site/mod_redshop_newsletter/language/it-IT/it-IT.mod_redshop_newsletter.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_newsletter
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_NEWSLETTER="redSHOP - Newsletter"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Modulo suffisso classe"
 COM_REDSHOP_NEWSLETTER_SUBSCRIPTION = "Iscrizione Newsletter"
 COM_REDSHOP_SUBSCRIBE = "Iscriviti"
@@ -8,4 +14,3 @@ COM_REDSHOP_NEWSLETTER = "Newsletter"
 COM_REDSHOP_ENTER_AN_EMAIL_ADDRESS = "Inserire un indirizzo e-mail."
 COM_REDSHOP_EMAIL_ADDRESS_NOT_VALID = "Inserire valido Indirizzo e-mail."
 COM_REDSHOP_ENTER_A_NAME = "Inserire un nome."
-MOD_REDSHOP_NEWSLETTER = "Redshop Newsletter"

--- a/modules/site/mod_redshop_pricefilter/language/da-DK/da-DK.mod_redshop_pricefilter.ini
+++ b/modules/site/mod_redshop_pricefilter/language/da-DK/da-DK.mod_redshop_pricefilter.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_pricefilter
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_PRICEFILTER="redSHOP - Price Filtering"
 COM_REDSHOP_REDSHOP_PRICE_FILTER_DESC = "Pris Filtrering Modul til redSHOP"
 COM_REDSHOP_MODULE_DESC = "redSHOP Product Tab Module"
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige over Scroller."
@@ -42,4 +48,3 @@ COM_REDSHOP_MAXIMUM_SLIDER_RANGE = "Maksimal Slider Range"
 COM_REDSHOP_PRODCUT_PRICE_YOU_SAVED = "Produkt Pris Du reddede"
 COM_REDSHOP_NO_PRODUCT_FOUND = "ingen fundet."
 COM_REDSHOP_LOADING = "Loading"
-MOD_REDSHOP_PRICEFILTER = "redSHOP Pricefilter"

--- a/modules/site/mod_redshop_pricefilter/language/en-GB/en-GB.mod_redshop_pricefilter.ini
+++ b/modules/site/mod_redshop_pricefilter/language/en-GB/en-GB.mod_redshop_pricefilter.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_pricefilter
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_pricefilter
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_PRICEFILTER="redSHOP - Price Filtering"
 COM_REDSHOP_REDSHOP_PRICE_FILTER_DESC="Price Filtering Module for redSHOP"
 COM_REDSHOP_MODULE_DESC="redSHOP Product Tab Module"
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
@@ -50,5 +48,4 @@ COM_REDSHOP_MAXIMUM_SLIDER_RANGE="Maximum Slider Range"
 COM_REDSHOP_PRODCUT_PRICE_YOU_SAVED="Product Price You saved"
 COM_REDSHOP_NO_PRODUCT_FOUND="No Product Found."
 COM_REDSHOP_LOADING="Loading"
-MOD_REDSHOP_PRICEFILTER="Redshop Pricefilter"
 COM_REDSHOP_CATEGORY="Category"

--- a/modules/site/mod_redshop_productcompare/language/da-DK/da-DK.mod_redshop_productcompare.ini
+++ b/modules/site/mod_redshop_productcompare/language/da-DK/da-DK.mod_redshop_productcompare.ini
@@ -1,6 +1,11 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_productcompare
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_PRODUCTCOMPARE="redSHOP - Products Compare"
 COM_REDSHOP_NO_PRODUCTS_TO_COMPARE = "Ingen produkter for at sammenligne"
 COM_REDSHOP_COMPARE_PRODUCTS = "Sammenlign Produkt"
-MOD_REDSHOP_PRODUCTCOMPARE = "redSHOP produkt Sammenlign"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Module Class Suffix"
 COM_REDSHOP_DELETE="Delete"
 COM_REDSHOP_COMPARE="Compare"

--- a/modules/site/mod_redshop_productcompare/language/en-GB/en-GB.mod_redshop_productcompare.ini
+++ b/modules/site/mod_redshop_productcompare/language/en-GB/en-GB.mod_redshop_productcompare.ini
@@ -1,14 +1,11 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_productcompare
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_productcompare
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_PRODUCTCOMPARE="redSHOP - Products Compare"
 COM_REDSHOP_NO_PRODUCTS_TO_COMPARE ="No Products to Compare"
 COM_REDSHOP_COMPARE_PRODUCTS ="Compare Product"
-MOD_REDSHOP_PRODUCTCOMPARE="Redshop Product Compare"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX="Module Class Suffix"
 COM_REDSHOP_DELETE="Delete"
 COM_REDSHOP_COMPARE="Compare"

--- a/modules/site/mod_redshop_productcompare/language/fr-FR/fr-FR.mod_redshop_productcompare.ini
+++ b/modules/site/mod_redshop_productcompare/language/fr-FR/fr-FR.mod_redshop_productcompare.ini
@@ -1,6 +1,11 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_productcompare
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_PRODUCTCOMPARE="redSHOP - Products Compare"
 COM_REDSHOP_NO_PRODUCTS_TO_COMPARE = "Pas de produits à comparer"
 COM_REDSHOP_COMPARE_PRODUCTS = "Comparer les produits"
-MOD_REDSHOP_PRODUCTCOMPARE = "Produit Redshop Comparer"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Suffixe de classe Module"
 COM_REDSHOP_DELETE="Delete"
 COM_REDSHOP_COMPARE="Compare"

--- a/modules/site/mod_redshop_products/language/da-DK/da-DK.mod_redshop_products.ini
+++ b/modules/site/mod_redshop_products/language/da-DK/da-DK.mod_redshop_products.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_products
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_PRODUCTS="redSHOP - Products"
 COM_REDSHOP_MODULE_DESC = "redSHOP Product Module"
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige over Scroller."
 COM_REDSHOP_PRETEXT_LBL = "Pre-tekst"
@@ -40,7 +46,6 @@ COM_REDSHOP_SHOW_VAT = "Vis moms"
 COM_REDSHOP_SHOW_VAT_DESC = "Vis pris med moms"
 COM_REDSHOP_PRODUCT_ON_SALE = "Produkt On Sale"
 COM_REDSHOP_SHOW_CHILD_PRODUCTS = "Vis produkter til børn"
-MOD_REDSHOP_PRODUCTS = "redSHOP Produkt"
 COM_REDSHOP_CATEGORY = "Kategori"
 COM_REDSHOP_OUT_OF_STOCK="Ikke på lager"
 COM_REDSHOP_AVAILABLE_STOCK="på lager"

--- a/modules/site/mod_redshop_products/language/de-DE/de-DE.mod_redshop_products.ini
+++ b/modules/site/mod_redshop_products/language/de-DE/de-DE.mod_redshop_products.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_products
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_PRODUCTS="redSHOP - Products"
 COM_REDSHOP_MODULE_DESC = "RedShop Produkt Module"
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige über Scroller."
 COM_REDSHOP_PRETEXT_LBL = "Pre-tekst"
@@ -40,7 +46,6 @@ COM_REDSHOP_SHOW_VAT = "Vis Mütter"
 COM_REDSHOP_SHOW_VAT_DESC = "Vis pris med Mütter"
 COM_REDSHOP_PRODUCT_ON_SALE = "Produkt On Sale"
 COM_REDSHOP_SHOW_CHILD_PRODUCTS = "Vis produkter til geboren"
-MOD_REDSHOP_PRODUCTS = "RedShop Produkt"
 COM_REDSHOP_CATEGORY = "Category"
 COM_REDSHOP_YES="Yes"
 COM_REDSHOP_NO="No"

--- a/modules/site/mod_redshop_products/language/en-GB/en-GB.mod_redshop_products.ini
+++ b/modules/site/mod_redshop_products/language/en-GB/en-GB.mod_redshop_products.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_products
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_products
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_PRODUCTS="redSHOP - Products"
 COM_REDSHOP_MODULE_DESC="redSHOP Product Module"
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
 COM_REDSHOP_PRETEXT_LBL="Pre-Text"
@@ -48,7 +46,6 @@ COM_REDSHOP_SHOW_VAT="Show VAT"
 COM_REDSHOP_SHOW_VAT_DESC="Show Price with VAT"
 COM_REDSHOP_PRODUCT_ON_SALE="Product On Sale"
 COM_REDSHOP_SHOW_CHILD_PRODUCTS="Show Child Products"
-MOD_REDSHOP_PRODUCTS="Redshop Product"
 COM_REDSHOP_CATEGORY="Category"
 COM_REDSHOP_OUT_OF_STOCK="Out of Stock"
 COM_REDSHOP_AVAILABLE_STOCK="In Stock"

--- a/modules/site/mod_redshop_products/language/it-IT/it-IT.mod_redshop_products.ini
+++ b/modules/site/mod_redshop_products/language/it-IT/it-IT.mod_redshop_products.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_products
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_PRODUCTS="redSHOP - Products"
 COM_REDSHOP_MODULE_DESC = "RedShop Produkt Module"
 COM_REDSHOP_PRETEXT = "DENNE tekst vil blive vist lige über Scroller".
 COM_REDSHOP_PRETEXT_LBL = "Pre-tekst"
@@ -40,7 +46,6 @@ COM_REDSHOP_SHOW_VAT = "Vis Mütter"
 COM_REDSHOP_SHOW_VAT_DESC = "Vis pris med Mütter"
 COM_REDSHOP_PRODUCT_ON_SALE = "Produkt in vendita"
 COM_REDSHOP_SHOW_CHILD_PRODUCTS = "produkter Vis til geboren"
-MOD_REDSHOP_PRODUCTS = "RedShop Produkt"
 COM_REDSHOP_CATEGORY = "Categoria"
 COM_REDSHOP_YES="Yes"
 COM_REDSHOP_NO="No"

--- a/modules/site/mod_redshop_promote_free_shipping/language/en-GB/en-GB.mod_redshop_promote_free_shipping.ini
+++ b/modules/site/mod_redshop_promote_free_shipping/language/en-GB/en-GB.mod_redshop_promote_free_shipping.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_promote_free_shipping
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_PROMOTE_FREE_SHIPPING="redSHOP - Promoting Free Shipping"
 COM_REDSHOP_SHIPPING_TEXT_LBL="If you order for &lt;span style=&#039;color:#FF0000&#039;&gt;%s&lt;/span&gt; more, you will get free shipping"
 COM_REDSHOP_FREE_SHIPPING_RATE_IS_IN_USED="Free shipping rate is in used"
 COM_REDSHOP_NO_SHIPPING_RATE_AVAILABLE="No Freeshipping rate is available."

--- a/modules/site/mod_redshop_search/language/da-DK/da-DK.mod_redshop_search.ini
+++ b/modules/site/mod_redshop_search/language/da-DK/da-DK.mod_redshop_search.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_promote_free_shipping
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_SEARCH="Redshop Search"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Modulo suffisso classe"
 COM_REDSHOP_PRODUCT_SEARCH = "Prodotti ricerca"
 COM_REDSHOP_KEYWORD = "parola chiave"

--- a/modules/site/mod_redshop_search/language/de-DE/de-DE.mod_redshop_search.ini
+++ b/modules/site/mod_redshop_search/language/de-DE/de-DE.mod_redshop_search.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_promote_free_shipping
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_SEARCH="Redshop Search"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Module Class Suffix"
 COM_REDSHOP_PRODUCT_SEARCH = "Produkte suchen"
 COM_REDSHOP_KEYWORD = "Stichwort"

--- a/modules/site/mod_redshop_search/language/en-GB/en-GB.mod_redshop_search.ini
+++ b/modules/site/mod_redshop_search/language/en-GB/en-GB.mod_redshop_search.ini
@@ -1,10 +1,7 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_search
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_promote_free_shipping
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
 MOD_REDSHOP_SEARCH="Redshop Search"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX="Module class suffix"

--- a/modules/site/mod_redshop_search/language/en-GB/en-GB.mod_redshop_search.sys.ini
+++ b/modules/site/mod_redshop_search/language/en-GB/en-GB.mod_redshop_search.sys.ini
@@ -1,1 +1,6 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_promote_free_shipping
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
 MOD_REDSHOP_SEARCH="Redshop Search"

--- a/modules/site/mod_redshop_search/language/it-IT/it-IT.mod_redshop_search.ini
+++ b/modules/site/mod_redshop_search/language/it-IT/it-IT.mod_redshop_search.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_promote_free_shipping
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_SEARCH="Redshop Search"
 COM_REDSHOP_PARAMMODULECLASSSUFFIX = "Modulo suffisso classe"
 COM_REDSHOP_PRODUCT_SEARCH = "Prodotti ricerca"
 COM_REDSHOP_KEYWORD = "parola chiave"

--- a/modules/site/mod_redshop_shoppergroup_product/language/da-DK/da-DK.mod_redshop_shoppergroup_product.ini
+++ b/modules/site/mod_redshop_shoppergroup_product/language/da-DK/da-DK.mod_redshop_shoppergroup_product.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_shoppergroup_product
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_SHOPPERGROUP_PRODUCT="redSHOP - ShopperGroup Product"
 COM_REDSHOP_MODULE_DESC = "redSHOP Product Module"
 COM_REDSHOP_PRETEXT = "Denne tekst vil blive vist lige over Scroller."
 COM_REDSHOP_PRETEXT_LBL = "Pre-tekst"
@@ -40,5 +46,3 @@ COM_REDSHOP_SHOW_VAT = "Vis moms"
 COM_REDSHOP_SHOW_VAT_DESC = "Vis pris med moms"
 COM_REDSHOP_CROP_TITLE_LENGTH = "Titel længde (afgrøde)"
 COM_REDSHOP_POST_TEXT = "Skriv tekst"
-
-MOD_REDSHOP_SHOPPERGROUP_PRODUCT = "redSHOP Shoppergroup Produkt"

--- a/modules/site/mod_redshop_shoppergroup_product/language/en-GB/en-GB.mod_redshop_shoppergroup_product.ini
+++ b/modules/site/mod_redshop_shoppergroup_product/language/en-GB/en-GB.mod_redshop_shoppergroup_product.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_shoppergroup_product
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_shoppergroup_product
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_SHOPPERGROUP_PRODUCT="redSHOP - ShopperGroup Product"
 COM_REDSHOP_MODULE_DESC="redSHOP Product Module"
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
 COM_REDSHOP_PRETEXT_LBL="Pre-Text"
@@ -48,5 +46,3 @@ COM_REDSHOP_SHOW_VAT="Show VAT"
 COM_REDSHOP_SHOW_VAT_DESC="Show Price with VAT"
 COM_REDSHOP_CROP_TITLE_LENGTH="Title length (crop)"
 COM_REDSHOP_POST_TEXT="Post text"
-
-MOD_REDSHOP_SHOPPERGROUP_PRODUCT="Redshop Shoppergroup Product"

--- a/modules/site/mod_redshop_shoppergrouplogo/language/da-DK/da-DK.mod_redshop_shoppergrouplogo.ini
+++ b/modules/site/mod_redshop_shoppergrouplogo/language/da-DK/da-DK.mod_redshop_shoppergrouplogo.ini
@@ -1,4 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_shoppergrouplogo
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_SHOPPERGROUPLOGO="redSHOP - Shoppergroup Logo"
 COM_REDSHOP_MODULE_DESC="Viser en shopper gruppe logo"
 COM_REDSHOP_THUMB_IMAGE_WIDTH="Shopper gruppe Logo bredde"
 COM_REDSHOP_THUMB_IMAGE_HEIGHT=Shopper gruppe Logo højde"
-MOD_REDSHOP_SHOPPERGROUPLOGO = "redSHOP Shoppergrouplogo"

--- a/modules/site/mod_redshop_shoppergrouplogo/language/en-GB/en-GB.mod_redshop_shoppergrouplogo.ini
+++ b/modules/site/mod_redshop_shoppergrouplogo/language/en-GB/en-GB.mod_redshop_shoppergrouplogo.ini
@@ -1,12 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_shoppergrouplogo
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_shoppergrouplogo
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_SHOPPERGROUPLOGO="redSHOP - Shoppergroup Logo"
 COM_REDSHOP_MODULE_DESC =" Displays a RedSHOP Shopper group logo"
 COM_REDSHOP_THUMB_IMAGE_WIDTH="ShopperGroup logo width"
 COM_REDSHOP_THUMB_IMAGE_HEIGHT="ShopperGroup logo height"
-MOD_REDSHOP_SHOPPERGROUPLOGO="Redshop Shoppergrouplogo"

--- a/modules/site/mod_redshop_who_bought/language/da-DK/da-DK.mod_redshop_who_bought.ini
+++ b/modules/site/mod_redshop_who_bought/language/da-DK/da-DK.mod_redshop_who_bought.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_who_bought
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_WHO_BOUGHT="redSHOP - Who Bought"
 COM_REDSHOP_MODULE_DESC = "Module Produit redSHOP"
 COM_REDSHOP_PRETEXT = "Ce texte sera affiché juste au-dessus de la molette."
 COM_REDSHOP_PRETEXT_LBL = "pré-texte»
@@ -46,4 +52,3 @@ COM_REDSHOP_VERTICAL_PRODUCT = "Afficher le produit verticalement?"
 COM_REDSHOP_VERTICAL_PRODUCT_DESC = "Afficher le produit verticalement"
 COM_REDSHOP_SHOW_VAT = "Afficher la TVA"
 COM_REDSHOP_SHOW_VAT_DESC = "Montrer Prix avec TVA"
-MOD_REDSHOP_WHO_BOUGHT = "redSHOP som købte"

--- a/modules/site/mod_redshop_who_bought/language/en-GB/en-GB.mod_redshop_who_bought.ini
+++ b/modules/site/mod_redshop_who_bought/language/en-GB/en-GB.mod_redshop_who_bought.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_who_bought
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_who_bought
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_WHO_BOUGHT="redSHOP - Who Bought"
 COM_REDSHOP_MODULE_DESC="redSHOP Product Module"
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
 COM_REDSHOP_PRETEXT_LBL="Pre-Text"
@@ -54,4 +52,3 @@ COM_REDSHOP_VERTICAL_PRODUCT="Display Product Vertically?"
 COM_REDSHOP_VERTICAL_PRODUCT_DESC="Display Product Vertically"
 COM_REDSHOP_SHOW_VAT="Show VAT"
 COM_REDSHOP_SHOW_VAT_DESC="Show Price with VAT"
-MOD_REDSHOP_WHO_BOUGHT="Redshop Who Bought"

--- a/modules/site/mod_redshop_wishlist/language/da-DK/da-DK.mod_redshop_wishlist.ini
+++ b/modules/site/mod_redshop_wishlist/language/da-DK/da-DK.mod_redshop_wishlist.ini
@@ -1,3 +1,9 @@
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_wishlist
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
+
+MOD_REDSHOP_WISHLIST ="redSHOP Ønskeseddel"
 COM_REDSHOP_MODULE_DESC =" redSHOP ønskeliste Modul"
 COM_REDSHOP_PRETEXT =" Denne tekst vil blive vist lige over Scroller."
 COM_REDSHOP_PRETEXT_LBL =" Pre-Text"
@@ -29,4 +35,3 @@ COM_REDSHOP_PRODUCT_OUTOFSTOCK_MESSAGE =" Beklager, produktet er på lager ..."
 COM_REDSHOP_THUMB_IMAGE_WIDTH =" Thumb Billedbredde"
 COM_REDSHOP_THUMB_IMAGE_HEIGHT =" Thumb Billedhøjde"
 COM_REDSHOP_VIEW_WISHLIST="Se ønskeseddel"
-MOD_REDSHOP_WISHLIST ="redSHOP Ønskeseddel"

--- a/modules/site/mod_redshop_wishlist/language/en-GB/en-GB.mod_redshop_wishlist.ini
+++ b/modules/site/mod_redshop_wishlist/language/en-GB/en-GB.mod_redshop_wishlist.ini
@@ -1,11 +1,9 @@
-; version 1.1.9.6
-; package Joomla.Site
-; subpackage mod_redshop_wishlist
-; author redWEB Aps
-; translation en-GB source redWEB Aps
-; copyright com_redshop (C) 2008 - 2012 redCOMPONENT.com
-; license GNU/GPL, see LICENSE.php
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_wishlist
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_WISHLIST="redSHOP - WishList"
 COM_REDSHOP_MODULE_DESC="redSHOP Wishlist Module"
 COM_REDSHOP_PRETEXT="This text will be displayed just above the Scroller."
 COM_REDSHOP_PRETEXT_LBL="Pre-Text"
@@ -37,4 +35,3 @@ COM_REDSHOP_PRODUCT_OUTOFSTOCK_MESSAGE="Sorry, product is out of stock..."
 COM_REDSHOP_THUMB_IMAGE_WIDTH="Thumb Image Width"
 COM_REDSHOP_THUMB_IMAGE_HEIGHT="Thumb Image Height"
 COM_REDSHOP_VIEW_WISHLIST="View Wishlist"
-MOD_REDSHOP_WISHLIST="Redshop Wishlist"

--- a/modules/site/mod_redshop_wishlist/language/fr-FR/fr-FR.mod_redshop_wishlist.ini
+++ b/modules/site/mod_redshop_wishlist/language/fr-FR/fr-FR.mod_redshop_wishlist.ini
@@ -1,8 +1,9 @@
-; $Id: fr-FR.ini $
-; Copyright (C) 2010. All rights reserved.
-; License http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL, see LICENSE.php
-; Note : All ini files need to be saved as UTF-8 - No BOM
+; Package     Redshop.Frontend
+; Subpackage  mod_redshop_wishlist
+; Copyright   Copyright (C) 2005 - 2013 redCOMPONENT.com. All rights reserved.
+; License     GNU General Public License version 2 or later; see LICENSE
 
+MOD_REDSHOP_WISHLIST ="redSHOP - liste de souhaits"
 COM_REDSHOP_MODULE_DESC="Module Liste de Préférence redSHOP"
 COM_REDSHOP_PRETEXT="Ce texte sera affiché juste au-dessus du Scroller."
 COM_REDSHOP_PRETEXT_LBL="Prétexte"
@@ -34,4 +35,3 @@ COM_REDSHOP_PRODUCT_OUTOFSTOCK_MESSAGE="Désolé, ce produit est épuisé (hors-
 COM_REDSHOP_THUMB_IMAGE_WIDTH="Largeur vignette"
 COM_REDSHOP_THUMB_IMAGE_HEIGHT="Hauteur vignette"
 COM_REDSHOP_VIEW_WISHLIST="Voir liste de préférence"
-MOD_REDSHOP_WISHLIST ="liste de souhaits Redshop"


### PR DESCRIPTION
In prior pull I added i18n support in modules by adding the sys file but I missed to then add the same string in the normal ini file for module adminstration. This pull solves this:

![title-module](https://f.cloud.github.com/assets/1375475/352491/72921262-a066-11e2-95e2-9af3717afede.png)
