### PR TITLE
Fix getting the component version

### DIFF
--- a/component/admin/models/configuration.php
+++ b/component/admin/models/configuration.php
@@ -865,7 +865,7 @@ class configurationModelconfiguration extends JModel
 	/* Get current version of redshop */
 	public function getcurrentversion()
 	{
-		$xmlfile = JPATH_SITE . DS . 'administrator' . DS . 'components' . DS . 'com_redshop' . DS . 'com_redshop.xml';
+		$xmlfile = JPATH_SITE . DS . 'administrator' . DS . 'components' . DS . 'com_redshop' . DS . 'redshop.xml';
 		$version = JText::_('COM_REDSHOP_FILE_NOT_FOUND');
 
 		if (file_exists($xmlfile))


### PR DESCRIPTION
Fix missing version release in redSHOP cpanel: 

![fix_version](https://f.cloud.github.com/assets/1375475/367109/b4ce4650-a29b-11e2-990a-acebbc51a0a9.png)
