### PR TITLE
problem creating build due to libraries

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -64,11 +64,11 @@
         </copy>
 
         <!-- Libraries -->
-        <copy todir="${www.dir}/libraries" overwrite="true">
+        <!--<copy todir="${www.dir}/libraries" overwrite="true">
             <fileset dir="${src}/libraries">
                 <include name="**" />
             </fileset>
-        </copy>
+        </copy>-->
 
         <!-- Media -->
         <copy todir="${www.dir}/media" overwrite="true">


### PR DESCRIPTION
#### Error generated during build

Execution of target "site" failed for the following reason: C:\wamp\www\github\redSHOP-1.2\build.xml:67:30: Directory C:\wamp\www\github\redSHOP-1.2.\libraries not found.

**BUILD FAILED**
C:\wamp\www\github\redSHOP-1.2\build.xml:67:30: Directory C:\wamp\www\github\redSHOP-1.2.\libraries not found.
Total time: 38.0748 seconds

---

**I just commented library code.**
