### PR TITLE
Searching product is wrong when we have many categories in a shopper gro...

### DIFF
--- a/component/site/helpers/product.php
+++ b/component/site/helpers/product.php
@@ -7672,14 +7672,18 @@ class producthelper
 			$catquery = "SELECT sg.shopper_group_categories FROM `#__redshop_shopper_group` as sg WHERE  sg.`shopper_group_id` = '" . $shopperGroupId . "' AND sg.shopper_group_portal=1";
 
 		$this->_db->setQuery($catquery);
-		$category_ids = $this->_db->loadObjectList();
+		$category_ids_obj = $this->_db->loadObjectList();
 		if(empty($category_ids))
 		{
 			$category_ids = "''";
 		}
+		else
+		{
+			$category_ids = $category_ids_obj[0]->shopper_group_categories;
+		}
 
 		$query = "SELECT product_id
-						FROM `#__redshop_product_category_xref` WHERE category_id IN (" . $category_ids[0]->shopper_group_categories . ")";
+						FROM `#__redshop_product_category_xref` WHERE category_id IN (" . $category_ids . ")";
 
 		$this->_db->setQuery($query);
 		$shopperprodata = $this->_db->loadObjectList();

--- a/component/site/helpers/product.php
+++ b/component/site/helpers/product.php
@@ -7671,8 +7671,15 @@ class producthelper
 		else
 			$catquery = "SELECT sg.shopper_group_categories FROM `#__redshop_shopper_group` as sg WHERE  sg.`shopper_group_id` = '" . $shopperGroupId . "' AND sg.shopper_group_portal=1";
 
+		$this->_db->setQuery($catquery);
+		$category_ids = $this->_db->loadObjectList();
+		if(empty($category_ids))
+		{
+			$category_ids = "''";
+		}
+
 		$query = "SELECT product_id
-						FROM `#__redshop_product_category_xref` WHERE category_id IN (" . $catquery . ")";
+						FROM `#__redshop_product_category_xref` WHERE category_id IN (" . $category_ids[0]->shopper_group_categories . ")";
 
 		$this->_db->setQuery($query);
 		$shopperprodata = $this->_db->loadObjectList();

--- a/component/site/helpers/product.php
+++ b/component/site/helpers/product.php
@@ -7673,7 +7673,7 @@ class producthelper
 
 		$this->_db->setQuery($catquery);
 		$category_ids_obj = $this->_db->loadObjectList();
-		if(empty($category_ids))
+		if(empty($category_ids_obj))
 		{
 			$category_ids = "''";
 		}


### PR DESCRIPTION
Searching product is wrong when we have many categories in a shopper group.

Please see the case as below:

Step 1: Create a new shopper group
![pic1](https://f.cloud.github.com/assets/3894971/567874/a44730e2-c6c4-11e2-9464-5a132f3b63df.png)

Step 2: Create a new user and choose the shopper group that was created
![pic2](https://f.cloud.github.com/assets/3894971/567875/a4baf266-c6c4-11e2-8840-13e41532b129.png)

Step 3: Log in with the user
![pic3](https://f.cloud.github.com/assets/3894971/567878/a4cb395a-c6c4-11e2-9863-94795853169d.png)

Step 4: Input "red" into search form
![pic4](https://f.cloud.github.com/assets/3894971/567876/a4c6ad5e-c6c4-11e2-970f-3ec824b28a9f.png)

The result is only 2 products (Actually, we have more than 2 products)
![pic5](https://f.cloud.github.com/assets/3894971/567877/a4c3640a-c6c4-11e2-8700-c621c747ffc4.png)
