### PR TITLE
[fix] Downloadable Product SEF url creation

### DIFF
--- a/component/admin/extras/sh404sef/sef_ext/com_redshop.php
+++ b/component/admin/extras/sh404sef/sef_ext/com_redshop.php
@@ -294,6 +294,12 @@ switch ($view)
 				$title[] = $cid;
 				$title[] = $layout;
 			}
+			elseif ($layout == 'downloadproduct')
+			{
+				$title[] = $layout;
+
+				shRemoveFromGETVarsList('tid');
+			}
 			else
 			{
 				$title[] = $layout;


### PR DESCRIPTION
- Before it was not possible to download product ( Product Download Type ) when sh404sef is enable. No sef rule was added.
