### PR TITLE
Fix the url is wrong when logout in my account page

### DIFF
--- a/component/site/controllers/login.php
+++ b/component/site/controllers/login.php
@@ -116,11 +116,11 @@ class LoginController extends JController
 
 		if ($item)
 		{
-			$link = JRoute::_($item->link . '&Itemid=' . $logout_itemid);
+			$link = JRoute::_($item->link . '&Itemid=' . $logout_itemid, false);
 		}
 		else
 		{
-			$link = JRoute::_('index.php?option=com_redshop');
+			$link = JRoute::_('index.php?option=com_redshop', false);
 		}
 
 		$app->logout();


### PR DESCRIPTION
When you logout on my account page, it will redirect to a url, but the url is wrong

Before
![1](https://f.cloud.github.com/assets/2959010/767253/0f62aeba-e87b-11e2-8d6b-3ada7502eb1a.png)

After
![2](https://f.cloud.github.com/assets/2959010/767252/0ef301aa-e87b-11e2-93ce-1f592824678c.png)
