### PR TITLE
Back-end Product Type selection JS Typo Reason: redDESIGN removal

### DIFF
--- a/component/admin/views/product_detail/tmpl/default.php
+++ b/component/admin/views/product_detail/tmpl/default.php
@@ -1001,17 +1001,23 @@ if($container_id) {
 		form.submit();
 	}
 
-	function changeProductDiv(product_type) {
-		document.getElementById("div_design").style.display = "none";
+	function changeProductDiv(product_type)
+	{
 		document.getElementById("div_file").style.display = "none";
 		document.getElementById("div_subscription").style.display = "none";
 		var opendiv = document.getElementById("div_" + product_type);
 		opendiv.style.display = 'block';
+
 		if (product_type == 'file')
+		{
 			document.getElementById("product_download1").checked = true;
+		}
 		else
+		{
 			document.getElementById("product_download1").checked = false;
+		}
 	}
+
 	function showBox(div) {
 		var opendiv = document.getElementById(div);
 


### PR DESCRIPTION
**Test**
- Go to product detail page back-end and try to change product type.

![screenshot from 2013-07-24 16 46 33](https://f.cloud.github.com/assets/2002921/848112/56cb0728-f453-11e2-9b0a-8fc7f783a7aa.png)
