### PR TITLE
[remove] requirement of helper.php as file is removed during redDESIGN removal

### DIFF
--- a/component/admin/views/configuration/view.html.php
+++ b/component/admin/views/configuration/view.html.php
@@ -13,7 +13,6 @@ jimport('joomla.application.component.view');
 
 require_once JPATH_COMPONENT_ADMINISTRATOR . '/helpers/template.php';
 require_once JPATH_COMPONENT_ADMINISTRATOR . '/helpers/extra_field.php';
-require_once JPATH_COMPONENT_ADMINISTRATOR . '/helpers/helper.php';
 require_once JPATH_COMPONENT_SITE . '/helpers/helper.php';
 
 class configurationViewconfiguration extends JView


### PR DESCRIPTION
[15:16:48] Henrik Sune Pedersen: Javier i got Errors on the redSHOP installed on loclahost when i go to components->redSHOP->and then configuration
[15:17:05] Henrik Sune Pedersen: 
Warning: require_once(/Applications/XAMPP/xamppfiles/htdocs/joomla25/administrator/components/com_redshop/helpers/helper.php) [function.require-once]: failed to open stream: No such file or directory in /Applications/XAMPP/xamppfiles/htdocs/joomla25/administrator/components/com_redshop/views/configuration/view.html.php on line 16

Fatal error: require_once() [function.require]: Failed opening required '/Applications/XAMPP/xamppfiles/htdocs/joomla25/administrator/components/com_redshop/helpers/helper.php' (include_path='.:/Applications/XAMPP/xamppfiles/lib/php:/Applications/XAMPP/xamppfiles/lib/php/pear') in /Applications/XAMPP/xamppfiles/htdocs/joomla25/administrator/components/com_redshop/views/configuration/view.html.php on line 16
