### PR TITLE
[fix] Added Mysql db quote to fix alter query in update

### DIFF
--- a/component/admin/sql/updates/mysql/1.3.sql
+++ b/component/admin/sql/updates/mysql/1.3.sql
@@ -1,4 +1,4 @@
 ALTER TABLE `#__redshop_product_subattribute_color` MODIFY `subattribute_color_name` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_general_ci;
-ALTER IGNORE TABLE #__redshop_product_attribute_property ADD `extra_field` VARCHAR( 250 ) NOT NULL;
-ALTER IGNORE TABLE #__redshop_product_subattribute_color ADD `extra_field` VARCHAR( 250 ) NOT NULL;
-ALTER IGNORE TABLE #__redshop_product ADD `minimum_per_product_total` INT( 11 ) NOT NULL;
+ALTER IGNORE TABLE `#__redshop_product_attribute_property` ADD `extra_field` VARCHAR( 250 ) NOT NULL;
+ALTER IGNORE TABLE `#__redshop_product_subattribute_color` ADD `extra_field` VARCHAR( 250 ) NOT NULL;
+ALTER IGNORE TABLE `#__redshop_product` ADD `minimum_per_product_total` INT( 11 ) NOT NULL;


### PR DESCRIPTION
- `minimum_per_product_total` was not found in upgrade from 1.2 to 1.3 which was resulting product saving error.
- Please try to save product after applying this patch.
