### PR TITLE
Blank product desc when import

### DIFF
--- a/component/admin/models/import.php
+++ b/component/admin/models/import.php
@@ -276,8 +276,17 @@ class importModelimport extends JModel
 								$rawdata['product_id'] = (int) $product_id;
 							}
 
-							$rawdata['product_desc'] = htmlentities($rawdata['product_desc']);
-							$rawdata['product_s_desc'] = htmlentities($rawdata['product_s_desc']);
+							// Product Description is optional - no need to add column in csv everytime.
+							if (isset($rawdata['product_desc']) === true)
+							{
+								$rawdata['product_desc'] = htmlentities($rawdata['product_desc']);
+							}
+
+							// Product Short Description is also optional - no need to add column in csv everytime.
+							if (isset($rawdata['product_s_desc']) === true)
+							{
+								$rawdata['product_s_desc'] = htmlentities($rawdata['product_s_desc']);
+							}
 
 							if (isset($rawdata['manufacturer_name']))
 							{


### PR DESCRIPTION
**Testing Instruction:**
- Export product csv from back-end import manager
- Remove two columns `product_desc` and `product_s_desc`
- Try to import modified csv
- Go to product detail page to ensure that product descriptions are not removed.
