### PR TITLE
Newsletter Sending issue - view was not load

### DIFF
--- a/component/admin/controllers/newsletter.php
+++ b/component/admin/controllers/newsletter.php
@@ -20,6 +20,7 @@ class newsletterController extends JController
 
 	public function send_newsletter_preview()
 	{
+		$view = $this->getView('newsletter', 'preview');
 		parent::display();
 	}
 

--- a/component/admin/views/newsletter/view.preview.php
+++ b/component/admin/views/newsletter/view.preview.php
@@ -16,7 +16,7 @@ class newsletterViewnewsletter extends JView
 {
 	public function display($tpl = null)
 	{
-		global $context;
+		$context = 'newsletter_preview';
 
 		$cid = JRequest::getVar('cid', array(0), 'post', 'array');
 
@@ -37,6 +37,7 @@ class newsletterViewnewsletter extends JView
 		JToolBarHelper::cancel('close', JText::_('JTOOLBAR_CLOSE'));
 
 		$uri = JFactory::getURI();
+		$app = JFactory::getApplication();
 
 		$filter_order = $app->getUserStateFromRequest($context . 'filter_order', 'filter_order', 'newsletter_id');
 		$filter_order_Dir = $app->getUserStateFromRequest($context . 'filter_order_Dir', 'filter_order_Dir', '');


### PR DESCRIPTION
- Reported by @trong-redweb 

**Testing:**
- Go to Newsletter - redSHOP Back-end
- Select any newsletter and try to send it via "Send newsletter" button
  - Before applying this patch, you will redirect to the same page.
  - After applying this page you will reach to newsletter filter page.

**General Information about this issue:**

@trong-redweb reported (or user may be) that it is working in redSHOP 1.2 and not in 1.3
But, it was actually not working in 1.2 or later.
It was working in 1.1.20
