### PR TITLE
Economic Plugin Problem

### DIFF
--- a/plugins/economic/economic/economic.php
+++ b/plugins/economic/economic/economic.php
@@ -8,8 +8,6 @@
  */
 
 defined('_JEXEC') or die;
-jimport('joomla.event.plugin');
-JPlugin::loadLanguage('plg_economic_economic');
 
 class plgEconomicEconomic extends JPlugin
 {


### PR DESCRIPTION
Duong reported issue with reference to ticket number

http://www.redcomponent.com/redcomponent-support/ticket/1514318186

If Economic plugin is enabled then after user save, it will raise fatal error because of those lines in economic plugin.

Fatal error: Using $this when not in object context in /home/barnestj/public_html/libraries/joomla/plugin/plugin.php on line 105
