### PR TITLE
Wishlist mail link - missing domain name

### DIFF
--- a/component/site/models/account.php
+++ b/component/site/models/account.php
@@ -471,7 +471,7 @@ class AccountModelaccount extends JModel
 			{
 				foreach ($MyWishlist as $row)
 				{
-					$link          = JRoute::_('index.php?option=com_redshop&view=product&pid=' . $row->product_id . '&Itemid=' . $Itemid);
+					$link          = JURI::root() . 'index.php?option=com_redshop&view=product&pid=' . $row->product_id . '&Itemid=' . $Itemid;
 					$thum_image    = $producthelper->getProductImage($row->product_id, $link, $w_thumb, $h_thumb);
 					$pname         = $row->product_name;
 					$pname         = $pname;


### PR DESCRIPTION
- Issue reported by @trong-redweb 
- add 1 product to wishlist
- send wishlist email
- the link sent out is something like http://index.php/.......
  I've just tested and what I received is : http://index.php/en/ultra-wash-gallon-for-semi-s-rv-s-and-trailers/glare-ultra-wash-for-semi-s-rv-s-and-trailers-gallon-size/menu-id-101.html
