### PR TITLE
Epay accept url issue with call back enable

### DIFF
--- a/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
+++ b/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
@@ -77,7 +77,7 @@ class plgRedshop_paymentrs_payment_epayv2 extends JPlugin
 		{
 			$formdata['cancelurl']   = JURI::base() . 'index.php?tmpl=component&option=com_redshop&view=order_detail&controller=order_detail&task=notify_payment&payment_plugin=rs_payment_epayv2&accept=0';
 			$formdata['callbackurl'] = JURI::base() . 'index.php?tmpl=component&option=com_redshop&view=order_detail&controller=order_detail&task=notify_payment&payment_plugin=rs_payment_epayv2&accept=1';
-			$formdata['accepturl']   = JURI::base() . 'index.php?option=com_redshop&view=order_detail&oid=' . $data['order_id'];
+			$formdata['accepturl']   = JURI::base() . 'index.php?option=com_redshop&view=order_detail&layout=receipt&oid=' . $data['order_id'];
 		}
 		else
 		{


### PR DESCRIPTION
- Reported by @duongctt 

**Testing instructions and issue:**
- In Epayv2 when call back enable
  ![2746880](https://f.cloud.github.com/assets/2002921/1008107/4ed50478-0b1a-11e3-99a1-dd48c25f89ca.png)
- According to New [checkout flow](https://github.com/redCOMPONENT-COM/redSHOP/wiki/History-of-redSHOP-Checkout-Flow#now-in-version--1196) ( actually it's old now :smiley_cat: ) it should redirect to **Order Receipt** page but it was redirecting to **Order Detail** page.
