### PR TITLE
mod_login 1.2 - Logout fails with sh404sef

### DIFF
--- a/modules/site/mod_redshop_login/tmpl/default.php
+++ b/modules/site/mod_redshop_login/tmpl/default.php
@@ -22,7 +22,7 @@ $Itemid = JRequest::getVar('Itemid');
 
 ?>
 <?php if ($type == 'logout') : ?>
-	<form action="index.php" method="post" name="login" id="form-login">
+	<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" name="login" id="form-login">
 		<?php if ($params->get('greeting')) : ?>
 			<div>
 				<?php if ($params->get('name')) : {


### PR DESCRIPTION
Comment from client

When i have sh404sef enabled then i can not logout on the Login module v 1.2.... It only redirects to frontpage but is still logged in.

Also in settings "Logout redirect url = Standard" do not stay on same page, but always redirect to frontpage.
