### PR TITLE
Manufacturer ordering Issue

### DIFF
--- a/component/admin/models/manufacturer_detail.php
+++ b/component/admin/models/manufacturer_detail.php
@@ -107,7 +107,11 @@ class manufacturer_detailModelmanufacturer_detail extends JModel
 		}
 
 		$row =& $this->getTable();
-		$data['ordering'] = $this->MaxOrdering();
+
+		if ($data['manufacturer_id'] == 0)
+		{
+			$data['ordering'] = $this->MaxOrdering();
+		}
 
 		if (!$row->bind($data))
 		{


### PR DESCRIPTION
reference ticket link

http://www.redcomponent.com/redcomponent-support/ticket/5514796185

Feedback from client

Hello, there is a problem with the ordering of the Manufacturers in the admin area. Every time you edit a manufacturer it changes its 'order' to one higher than the last one, so it then becomes the last one, even though we have not changed it.
