### PR TITLE
Fix zipcode query

### DIFF
--- a/component/admin/tables/zipcode_detail.php
+++ b/component/admin/tables/zipcode_detail.php
@@ -45,7 +45,7 @@ class Tablezipcode_detail extends JTable
 		$db = JFactory::getDbo();
 
 		$q = "SELECT *  FROM " . $this->_table_prefix . "zipcode"
-			. " WHERE zipcode = " . (int) $this->zipcode
+			. " WHERE zipcode = " . $db->quote($this->zipcode)
 			. " AND zipcode_id !=  " . (int) $this->zipcode_id
 			. " AND country_code =" . $db->quote($this->country_code);
 


### PR DESCRIPTION
Zipcodes must be treated as strings because there are some like 08074
