### PR TITLE
REDSHOP-943 Product Ordering issue in fron-end category detail page

### DIFF
--- a/component/site/models/category.php
+++ b/component/site/models/category.php
@@ -409,7 +409,7 @@ class CategoryModelCategory extends JModel
 			$value = (isset($item)) ? $item->params->get('order_by', 'p.product_name ASC') : DEFAULT_PRODUCT_ORDERING_METHOD;
 		}
 
-		$orderby = " ORDER BY " . $db->quote($value);
+		$orderby = " ORDER BY " . $db->escape($value);
 
 		return $orderby;
 	}


### PR DESCRIPTION
Ordering category product detail page.
Query is look like:
SELECT \* FROM #_redshop_product AS p LEFT JOIN #redshop_product_category_xref AS pc ON pc.product_id=p.product_id LEFT JOIN #redshop_category AS c ON c.category_id=pc.category_id LEFT JOIN #_redshop_manufacturer AS m ON m.manufacturer_id=p.manufacturer_id WHERE p.published = 1 AND p.expired = 0 AND pc.category_id = 18 AND p.product_parent_id = 0 ORDER BY 'pc.ordering ASC'

Problem: In query `ORDER BY 'pc.ordering ASC'` is wrong.
