### PR TITLE
Reset Passord Problem with Sh404SEF

### DIFF
--- a/component/admin/extras/sh404sef/sef_ext/com_redshop.php
+++ b/component/admin/extras/sh404sef/sef_ext/com_redshop.php
@@ -406,6 +406,13 @@ switch ($view)
 
 		$title[] = $sh_LANG[$shLangIso]['_REDSHOP_PASSWORD'];
 		shRemoveFromGETVarsList('view');
+
+		if ($layout != "")
+		{
+			$title[] = $layout;
+			shRemoveFromGETVarsList('layout');
+		}
+
 		break;
 
 	case 'registration':


### PR DESCRIPTION
Reference Ticket link

http://redcomponent.com/redcomponent-support/ticket/2114875157

When the customer places the emailed token - nothing happens? 

When Sh404SEF is on because of layout is missing it will always redirect to reset password link instead of token layout.
