### PR TITLE
REDSHOP-1162 #comment AcyMailing Newsletters Plugin doesn't work

### DIFF
--- a/plugins/acymailing/redshop/redshop.php
+++ b/plugins/acymailing/redshop/redshop.php
@@ -129,7 +129,7 @@ class plgAcymailingRedshop extends JPlugin
 	public function getProduct($product_id)
 	{
 		require_once JPATH_ADMINISTRATOR . '/components/com_redshop/helpers/template.php';
-		$redTemplate = new producthelper;
+		$redTemplate = new Redtemplate;
 
 		$prtemplate_id = trim($this->params->get('product_template', 1));
 		$prtemplate = $redTemplate->getTemplate('product_content_template', $prtemplate_id);


### PR DESCRIPTION
- The function preview of acymailing component die when user add tag product of redshop.
