### PR TITLE
RD-132: Fix warning in edit

### DIFF
--- a/component/admin/models/product_detail.php
+++ b/component/admin/models/product_detail.php
@@ -196,12 +196,8 @@ class Product_DetailModelProduct_Detail extends JModel
 			$detail->quantity_selectbox_value   = (isset($data['quantity_selectbox_value'])) ? $data['quantity_selectbox_value'] : null;
 			$detail->preorder                   = (isset($data['preorder'])) ? $data['preorder'] : 'global';
 			$detail->minimum_per_product_total  = (isset($data['minimum_per_product_total'])) ? $data['minimum_per_product_total'] : 0;
-			$detail->attribute_set_id           = 0;
-
-			if (isset($data['attribute_set_id']))
-			{
-				$detail->attribute_set_id = $data['attribute_set_id'];
-			}
+			$detail->attribute_set_id           = (isset($data['attribute_set_id'])) ? $data['attribute_set_id'] : 0;
+			$detail->append_to_global_seo		= (isset($data['append_to_global_seo'])) ? $data['append_to_global_seo'] : JText::_('COM_REDSHOP_APPEND_TO_GLOBAL_SEO');
 
 			$this->data                         = $detail;
 


### PR DESCRIPTION
Fix Warning error on https://redweb.atlassian.net/browse/RD-132

When select template, the form has been submit and re-fill all fields by data (which is get in $_POST).

The problem is the variable "append_to_global_seo" is not re-create after form submit.
