### PR TITLE
REDSHOP-1152 #Shopping Cart malfunctions when removing a product (that has attributes added)

### DIFF
--- a/component/site/models/cart.php
+++ b/component/site/models/cart.php
@@ -138,12 +138,6 @@ class CartModelCart extends JModel
 			$db->setQuery($sql);
 			$deletedrs = $db->loadResultArray();
 
-			$sql = "SELECT product_id FROM " . $this->_table_prefix . "cart "
-				. "WHERE session_id = " . $db->quote($session_id) . " "
-				. "AND section='product' ";
-			$db->setQuery($sql);
-			$includedrs = $db->loadResultArray();
-
 			$cart = $session->get('cart');
 
 			if ($cart)
@@ -153,11 +147,6 @@ class CartModelCart extends JModel
 				for ($j = 0; $j < $idx; $j++)
 				{
 					if (count($deletedrs) > 0 && in_array($cart[$j]['product_id'], $deletedrs))
-					{
-						$this->delete($j);
-					}
-
-					if (count($includedrs) > 0 && !in_array($cart[$j]['product_id'], $includedrs))
 					{
 						$this->delete($j);
 					}


### PR DESCRIPTION
1 - product A - attribute S
2 - product A - attribute M
3 - product A - attribute L
4 - poduct B
then remove 2, after that 1, 4 also disappear, only 3 remains.
