### PR TITLE
REDSHOP-1207 #comment Terms and Conditions light box doesn't work when changing payment method in checkout step

### DIFF
--- a/component/site/assets/js/common.js
+++ b/component/site/assets/js/common.js
@@ -1086,6 +1086,15 @@ function onestepCheckoutProcess(objectname,classname)
 					document.getElementById('divRedshopCart').innerHTML = document.getElementById('onestepdisplaycart').innerHTML;
 				}
 				document.getElementById('responceonestep').innerHTML = "";
+				
+				SqueezeBox.initialize({});
+				 
+				$$('a.modal').each(function(el) {
+					el.addEvent('click', function(e) {
+						new Event(e).stop();
+						SqueezeBox.fromElement(el);
+					});
+				});
 			}
 		};
 		if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent))


### PR DESCRIPTION
In redSHOP 1.3.3.1, when users go to checkout and change payment method (if there are more than 1 payment method), terms and conditions light box doesn't work correctly.
