### PR TITLE
REDSHOP-1603 [fix] To make zero vat if price is zero

### DIFF
--- a/component/admin/models/order_detail.php
+++ b/component/admin/models/order_detail.php
@@ -779,7 +779,13 @@ class order_detailModelorder_detail extends JModel
 		}
 
 		$customer_note = $data['customer_note'];
-		$product_tax = $producthelper->getProductTax($product_id, $productPrice, $user_id);
+
+		$product_tax = 0;
+
+		if ($productPrice > 0)
+		{
+			$product_tax = $producthelper->getProductTax($product_id, $productPrice, $user_id);
+		}
 
 		if ($productPrice_new < 0)
 		{


### PR DESCRIPTION
- Product price is zero but VAT applied to price is not zero. This PR contain fix for it. 
- To reproduce this issue, try to place an order in back-end and update price to zero and check.

![img_24032014_115337](https://f.cloud.github.com/assets/2002921/2498968/89521320-b34e-11e3-8a6a-6abee3bc7766.png)

---

cc: @JerryChr 
