### PR TITLE
REDSHOP-1302 #comment Can not checkout using dotpay payment plugin

### DIFF
--- a/plugins/redshop_payment/rs_payment_dotpay/rs_payment_dotpay/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_dotpay/rs_payment_dotpay/extra_info.php
@@ -36,7 +36,7 @@ else
 	?>
 
 	<strong>To make a payment, click on the image below:</strong>
-	<form action="https://ssl.dotpay.pl" method="post" id="dotpay">
+	<form action="https://ssl.dotpay.pl/pay.php" method="post"id="dotpay">
 		<div style="text-align: center; margin-top: 25px; margin-bottom: 25px;">
 			<input type="image" name="submit"
 			       src="<?php echo JURI::base() ?>plugins/redshop_payment/rs_payment_dotpay/dotpay.jpg" border="0"


### PR DESCRIPTION
issue:
- when client used this plugin to pay product
- On step final, when they checkout.the problem is this plugin redirect to home page of dotpay.pl 
- it have to redirect to the page checkout and show order of dotpay.com, not home page of dotpay.pl

@gunjanpatel 
Could you please help me check it. :) . thank a lot.
if you need the account to test :) , i will give you on private chat :)
