### PR TITLE
[fix] Notice when country not selected in back-end vat

### DIFF
--- a/component/admin/helpers/configuration.php
+++ b/component/admin/helpers/configuration.php
@@ -1311,6 +1311,11 @@ class Redconfiguration
 
 	public function getStateCode($conid, $tax_code)
 	{
+		if (empty($tax_code))
+		{
+			return null;
+		}
+
 		$db = JFactory::getDbo();
 		$query = 'SELECT  state_3_code , show_state FROM ' . $this->_table_prefix . 'state '
 		. 'WHERE state_2_code LIKE ' . $db->quote($tax_code)


### PR DESCRIPTION
- Go to `administrator/index.php?option=com_redshop&view=tax_group_detail&task=edit&cid[]=1`
- Add VAT Rate without selecting State.
  ![joomla2 - administration - vat rates 2014-04-08 17-48-26](https://cloud.githubusercontent.com/assets/2002921/2643237/e8a5796e-bf17-11e3-9896-fd37c68a2b74.png)
