### PR TITLE
REDSHOP-1369 Fix wrong input filter converting strings into ints

### DIFF
--- a/component/admin/helpers/extra_field.php
+++ b/component/admin/helpers/extra_field.php
@@ -81,8 +81,6 @@ class extra_field
 
 		if ($field_name != "")
 		{
-			$field_name = explode(',', $field_name);
-			$field_name = implode(',', $field_name);
 			$q .= "AND field_name IN ($field_name) ";
 		}
 

--- a/component/admin/helpers/extra_field.php
+++ b/component/admin/helpers/extra_field.php
@@ -81,6 +81,9 @@ class extra_field
 
 		if ($field_name != "")
 		{
+			$field_name = explode(',', $field_name);
+			JArrayHelper::toString($field_name);
+			$field_name = implode(',', $field_name);
 			$q .= "AND field_name IN ($field_name) ";
 		}
 

--- a/component/admin/helpers/extra_field.php
+++ b/component/admin/helpers/extra_field.php
@@ -82,7 +82,6 @@ class extra_field
 		if ($field_name != "")
 		{
 			$field_name = explode(',', $field_name);
-			JArrayHelper::toInteger($field_name);
 			$field_name = implode(',', $field_name);
 			$q .= "AND field_name IN ($field_name) ";
 		}


### PR DESCRIPTION
related to: http://redcomponent.com/redcomponent-support/ticket/8417415910

There is not task for ticket, but I found bug in local and fixed it, field name would be string and there is no need to convert it into integer.
