### PR TITLE
REDSHOP-1463 Fix notice in price view back-end - undefine list variable

### DIFF
--- a/component/admin/views/prices/view.html.php
+++ b/component/admin/views/prices/view.html.php
@@ -29,19 +29,19 @@ class pricesViewprices extends JView
 		JToolBarHelper::editListX();
 		JToolBarHelper::deleteList();
 
-		$limitstart = $app->getUserStateFromRequest($context . 'limitstart', 'limitstart', '0');
-		$limit      = $app->getUserStateFromRequest($context . 'limit', 'limit', '10');
+		$limitstart        = $app->getUserStateFromRequest($context . 'limitstart', 'limitstart', '0');
+		$limit             = $app->getUserStateFromRequest($context . 'limit', 'limit', '10');
 
-		$total      = $this->get('Total');
-		$media      = $this->get('Data');
-		$product_id = $this->get('ProductId');
+		$total             = $this->get('Total');
+		$media             = $this->get('Data');
+		$product_id        = $this->get('ProductId');
 
-		$pagination = new JPagination($total, $limitstart, $limit);
-		$this->user = JFactory::getUser();
-		$this->lists = $lists;
-		$this->media = $media;
-		$this->product_id = $product_id;
-		$this->pagination = $pagination;
+		$pagination        = new JPagination($total, $limitstart, $limit);
+		$this->user        = JFactory::getUser();
+
+		$this->media       = $media;
+		$this->product_id  = $product_id;
+		$this->pagination  = $pagination;
 		$this->request_url = $uri->toString();
 
 		parent::display($tpl);


### PR DESCRIPTION
Found the notice when accessing product price view. 
You may go to price view from product detail page or via side menu.

![price-view-notice](https://cloud.githubusercontent.com/assets/2002921/3271935/89d5e520-f312-11e3-8f77-754fab64e665.png)
