### PR TITLE
REDSHOP-1493 Gls option should be visible

### DIFF
--- a/component/site/helpers/cart.php
+++ b/component/site/helpers/cart.php
@@ -3519,7 +3519,7 @@ class rsCarthelper
 
 			$template_desc = "<div></div>";
 		}
-		elseif ($rateExist == 1 && $extrafield_total == "")
+		elseif ($rateExist == 1 && $extrafield_total == "" && $classname != "default_shipping_GLS")
 		{
 			$template_desc = "<div style='display:none;'>" . $template_desc . "</div>";
 		}


### PR DESCRIPTION
1) Install gls shipping plugin
2) install rs_label plugin
3) add {gls_shipping_location} into shipping_method template in rate loop
4) create demo rate in gls shipping plugin
5) make sure you have disabled all available shipping plugin to test this fix.
6) if you dont apply this patch, you wont see this options.
![5293263](https://cloud.githubusercontent.com/assets/2002921/5120797/8c3c35a2-70ae-11e4-9759-b25203b99945.png)

which actually should be visible.
