### PR TITLE
REDSHOP-1468 Order mail is sending out multiple times

### DIFF
--- a/component/admin/helpers/order.php
+++ b/component/admin/helpers/order.php
@@ -444,7 +444,7 @@ class order_functions
 				$redshopMail = new redshopMail;
 
 				// Send Order Mail After Payment
-				if (ORDER_MAIL_AFTER)
+				if (ORDER_MAIL_AFTER && $data->order_status_code == "C")
 				{
 					$redshopMail->sendOrderMail($order_id);
 				}
@@ -845,7 +845,7 @@ class order_functions
 				// Send the Order mail
 				$redshopMail = new redshopMail;
 
-				if (ORDER_MAIL_AFTER)
+				if (ORDER_MAIL_AFTER && $newstatus == 'C')
 				{
 					$redshopMail->sendOrderMail($order_id);
 				}


### PR DESCRIPTION
1) set http://awesomescreenshot.com/0dc35w093a option in configuration
2) place order confirm and paid it
3) update status from confirm to something else like shipped or something like that. status can be  changed here http://awesomescreenshot.com/07a35w1586
4) you will receive two mails order mail and order status mail, which is wrong only order status mail should be sent,
5) with this fix this should be fixed.
