### PR TITLE
REDSHOP-1332 fixes query error, missing space

### DIFF
--- a/component/admin/models/question_detail.php
+++ b/component/admin/models/question_detail.php
@@ -213,7 +213,7 @@ class question_detailModelquestion_detail extends JModel
 	 */
 	public function MaxOrdering()
 	{
-		$query = "SELECT (MAX(ordering)+1) FROM #__redshop_customer_question"
+		$query = "SELECT (MAX(ordering)+1) FROM #__redshop_customer_question "
 			. "WHERE parent_id=0 ";
 		$this->_db->setQuery($query);
 


### PR DESCRIPTION
error in your SQL syntax near 'FROM j_redshop_customer_questionWHERE parent_id=0'
