### PR TITLE
Add a joomla group to manage the removal of configuration.php

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -15,3 +15,5 @@ modules:
             user: ''
             password: ''
             dump: tests/_data/dump.sql
+extensions:
+    enabled: [JoomlaGroup]

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -3,3 +3,4 @@
 
 
 \Codeception\Util\Autoload::registerSuffix('Page', __DIR__.DIRECTORY_SEPARATOR.'_pages');
+\Codeception\Util\Autoload::registerSuffix('Group', __DIR__.DIRECTORY_SEPARATOR.'_groups');

--- a/tests/_groups/JoomlaGroup.php
+++ b/tests/_groups/JoomlaGroup.php
@@ -1,0 +1,29 @@
+<?php
+
+use \Codeception\Event\TestEvent;
+/**
+* Group class is Codeception Extension which is allowed to handle to all internal events.
+* This class itself can be used to listen events for test execution of one particular group.
+* It may be especially useful to create fixtures data, prepare server, etc.
+*
+* INSTALLATION:
+*
+* To use this group extension, include it to "extensions" option of global Codeception config.
+*/
+
+class JoomlaGroup extends \Codeception\Platform\Group
+{
+    public static $group = 'joomla';
+
+    public function _before(TestEvent $e)
+    {
+	    // Remove Joomla-cms old configuration.php file before do a clean joomla installation
+	    $joomlaConfigurationFile = 'tests/system/joomla-cms/configuration.php';
+
+	    if (file_exists($joomlaConfigurationFile))
+	    {
+		    chmod($joomlaConfigurationFile, 0777);
+		    unlink($joomlaConfigurationFile);
+	    }
+    }
+}

--- a/tests/acceptance/InstallJoomlaCept.php
+++ b/tests/acceptance/InstallJoomlaCept.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
+$scenario->group('joomla');
 $I = new AcceptanceTester($scenario);
 $I->wantTo("install-joomla");
 $I->amOnPage("tests/system/joomla-cms/installation/index.php");


### PR DESCRIPTION
This pull uses the Codeception Groups feature to ensure that configuration.php is removed from joomla-cms every time we execute JoomlaInstall test.

See line 2 in tests/acceptance/InstallJoomlaCept.php
