### PR TITLE
REDSHOP-1439 subproperty is required even though it is deleted

### DIFF
--- a/component/admin/models/product_detail.php
+++ b/component/admin/models/product_detail.php
@@ -4161,13 +4161,15 @@ class Product_DetailModelProduct_Detail extends JModel
 	{
 		$producthelper = new producthelper;
 
+		$subPropertyList = $producthelper->getAttibuteSubProperty(0, $subattribute_id);
+
 		if ($sp)
 		{
 			$subproperty[0]->subattribute_color_id = $sp;
 		}
 		else
 		{
-			$subproperty = $producthelper->getAttibuteSubProperty(0, $subattribute_id);
+			$subproperty = $subPropertyList;
 		}
 
 		for ($j = 0; $j < count($subproperty); $j++)
@@ -4178,6 +4180,15 @@ class Product_DetailModelProduct_Detail extends JModel
 			$this->_db->setQuery($query);
 			$this->_db->query();
 			$this->delete_image($subproperty[$j]->subattribute_color_image, 'subcolor');
+		}
+
+		if (count($subPropertyList) <= 1)
+		{
+			$query = "UPDATE #__redshop_product_attribute_property
+						SET `setrequire_selected` = '0'
+						WHERE `property_id` = " . (int) $subattribute_id;
+			$this->_db->setQuery($query);
+			$this->_db->query();
 		}
 	}
 
@@ -4193,13 +4204,15 @@ class Product_DetailModelProduct_Detail extends JModel
 	{
 		$producthelper = new producthelper;
 
+		$propertyList  = $producthelper->getAttibuteProperty(0, $attribute_id);
+
 		if ($property_id)
 		{
 			$property[0]->property_id = $property_id;
 		}
 		else
 		{
-			$property = $producthelper->getAttibuteProperty(0, $attribute_id);
+			$property = $propertyList;
 		}
 
 		for ($j = 0; $j < count($property); $j++)
@@ -4215,6 +4228,15 @@ class Product_DetailModelProduct_Detail extends JModel
 				$this->delete_image($property[$j]->property_image, 'product_attributes');
 				$this->delete_subprop(0, $property_id);
 			}
+		}
+
+		if (count($propertyList) <= 1)
+		{
+			$query = "UPDATE #__redshop_product_attribute
+						SET `attribute_required` = '0'
+						WHERE `attribute_id` = " . (int) $attribute_id;
+			$this->_db->setQuery($query);
+			$this->_db->query();
 		}
 
 		exit;

--- a/component/admin/models/product_detail.php
+++ b/component/admin/models/product_detail.php
@@ -4163,6 +4163,11 @@ class Product_DetailModelProduct_Detail extends JModel
 
 		$subPropertyList = $producthelper->getAttibuteSubProperty(0, $subattribute_id);
 
+		if (count($subPropertyList) == 0)
+		{
+			$subproperty = array('0' => new stdClass);
+		}
+
 		if ($sp)
 		{
 			$subproperty[0]->subattribute_color_id = $sp;
@@ -4179,7 +4184,12 @@ class Product_DetailModelProduct_Detail extends JModel
 					  AND subattribute_color_id= '" . $subproperty[$j]->subattribute_color_id . "'";
 			$this->_db->setQuery($query);
 			$this->_db->query();
-			$this->delete_image($subproperty[$j]->subattribute_color_image, 'subcolor');
+
+			if (isset($subproperty[$j]->subattribute_color_image)
+				&& $subproperty[$j]->subattribute_color_image)
+			{
+				$this->delete_image($subproperty[$j]->subattribute_color_image, 'subcolor');
+			}
 		}
 
 		if (count($subPropertyList) <= 1)


### PR DESCRIPTION
testing details,

1) create attribute under product in back-end
2) create property and subproperty required 
3) now go to front-end check, it will ask you to select subproperty which is correct
4) now delete all subproperty and now go to front-end it will still ask for you to select subproperty which has been deleted.
5) apply my patch create subproperty again and delete all subproperties, now go to front-end, try to add product to cart, error message should be gone.

NOTE: Ajax addtocart should be enabled.
