### PR TITLE
DHUNTER-422 # Buggy zoom function can cause dual‐select on color change

### DIFF
--- a/plugins/system/redproductzoom/js/redproductzoom.js
+++ b/plugins/system/redproductzoom/js/redproductzoom.js
@@ -53,6 +53,8 @@ function preloadSlimbox(parameters)
 				ez.closeAll();
 				ez.refresh();
 
+				$('.zoomContainer').remove();
+
 				//Create the image swap from the gallery
 				$('#'+ez.options.gallery + ' a').click( function(e) {
 
@@ -87,7 +89,7 @@ function preloadSlimbox(parameters)
 
 	});
 
-	if (parameters.isenable) 
+	if (parameters.isenable)
 	{
         var imgoptions = {handler: 'image'};
         redBOX.initialize({});


### PR DESCRIPTION
```
1. Go to any product that has several colors, and images available.
2. Click on a color that isn't already chosen.
3. While waiting for the script to change the image, hover over the current image. The zoom will activate just before the image is switched, and won't go away. If you hover over the new image, another zoom appears.
4. You need to refresh to fix the problem.

While this could be considered an edge scenario, I'd like to point out that I stumbled upon it accidentally. The reason it's so likely to occur in the first place, is due to the non‐instant change of the RedWeb B2B side 1 image, leaving a good second for the user to accidentally move their cursor back over the image, causing this problem.
```
