### PR TITLE
REDSHOP-1482 Fixed search inconsistent results

### DIFF
--- a/component/site/models/search.php
+++ b/component/site/models/search.php
@@ -265,7 +265,11 @@ class RedshopModelSearch extends JModel
 
 		if ($defaultSearchType == "")
 		{
-			$defaultSearchType = 'product_name';
+			$defaultSearchType = JRequest::getCmd('search_type');
+			if(empty($defaultSearchType))
+			{
+				$defaultSearchType = 'product_name';
+			}
 		}
 
 		if ($defaultSearchType == "name_number")

--- a/component/site/models/search.php
+++ b/component/site/models/search.php
@@ -265,12 +265,7 @@ class RedshopModelSearch extends JModel
 
 		if ($defaultSearchType == "")
 		{
-			$defaultSearchType = JRequest::getCmd('search_type');
-
-			if (empty($defaultSearchType))
-			{
-				$defaultSearchType = 'product_name';
-			}
+			$defaultSearchType = JRequest::getCmd('search_type', 'product_name');
 		}
 
 		if ($defaultSearchType == "name_number")

--- a/component/site/models/search.php
+++ b/component/site/models/search.php
@@ -266,7 +266,8 @@ class RedshopModelSearch extends JModel
 		if ($defaultSearchType == "")
 		{
 			$defaultSearchType = JRequest::getCmd('search_type');
-			if(empty($defaultSearchType))
+
+			if (empty($defaultSearchType))
 			{
 				$defaultSearchType = 'product_name';
 			}

--- a/component/site/views/search/view.html.php
+++ b/component/site/views/search/view.html.php
@@ -152,12 +152,12 @@ class RedshopViewSearch extends JView
 			$texts            = new text_library;
 			$stockroomhelper  = new rsstockroomhelper;
 
-			$Itemid      = JRequest::getInt('Itemid');
-			$search_type = JRequest::getCmd('search_type');
-			$cid         = JRequest::getInt('category_id');
+			$Itemid         = JRequest::getInt('Itemid');
+			$search_type    = JRequest::getCmd('search_type');
+			$cid            = JRequest::getInt('category_id');
+			$manufacture_id = JRequest::getInt('manufacture_id');
 
 			$manisrch       = $this->search;
-			$manufacture_id = $manisrch[0]->manufacturer_id;
 			$templateid     = JRequest::getInt('templateid');
 
 			// Cmd removes space between to words

--- a/component/site/views/search/view.html.php
+++ b/component/site/views/search/view.html.php
@@ -729,7 +729,8 @@ class RedshopViewSearch extends JView
 				'order_by'       => $getorderby,
 				'category_id'    => $cid,
 				'Itemid'         => $Itemid,
-				'limit'          => $limit
+				'limit'          => $limit,
+				'search_type'    => $search_type
 			);
 			$router->setVars($vars);
 			unset($vars);


### PR DESCRIPTION
The search_type parameter wasn't being passed correctly, and when using pagination, you wouldn't receive it and default to just searching by name. This lead to inconsistent results when searching, because the first page did get the search_type parameter at first, but when clicking on a page number you wouldn't, so the resulsts on page 1 would differ depending on how you'd access them.

And of course, the rest of the pages weren't displaying the appropriate results.

This pull request makes it so the search_type is sent and set in the model method.
