### PR TITLE
AT-219 #comment Fix e-conomic plugin call - Before bind to one

### DIFF
--- a/component/admin/helpers/economic.php
+++ b/component/admin/helpers/economic.php
@@ -42,7 +42,7 @@ class economic
 		$this->_order_functions = new order_functions;
 		$this->_stockroomhelper = new rsstockroomhelper;
 
-		JPluginHelper::importPlugin('economic', 'economic');
+		JPluginHelper::importPlugin('economic');
 		$this->_dispatcher = JDispatcher::getInstance();
 	}
 


### PR DESCRIPTION
Support Multiple e-conomic plugin from now. For ideal shop, only one should be enable. 
#### For Example:

![kontormoebler dk](https://cloud.githubusercontent.com/assets/2002921/4202668/ec4b6462-3829-11e4-94a5-e7e90117d9f1.png)

This will be helpful when we will need to hack core economic plugin with some additional features only for specific sites or clients.
#### Testing this PR
- Create demo e-conomic account from http://e-conomic.com/ 
- Enable plugin and add credentials
- Place and order and test
