### PR TITLE
REDSHOP-1550 Voucher/Coupon codes used more than once per order

### DIFF
--- a/component/site/helpers/cart.php
+++ b/component/site/helpers/cart.php
@@ -4182,7 +4182,7 @@ class rsCarthelper
 					case 4:
 						if ($valueExist)
 						{
-							$return = true;
+							$return = false;
 						}
 						break;
 
@@ -4352,7 +4352,7 @@ class rsCarthelper
 					case 4:
 						if ($valueExist)
 						{
-							$return = true;
+							$return = false;
 						}
 						break;
 					case 3:


### PR DESCRIPTION
This PR fixes the problem, which contrary to what the issue specifies, also applies to coupons.

The same code can't be used more than once per order, avoiding users abusing this and getting the order total to zero.
