### PR TITLE
REDSHOP-1554 Backslashes shown in the front-end removed

### DIFF
--- a/component/admin/helpers/extra_field.php
+++ b/component/admin/helpers/extra_field.php
@@ -131,7 +131,7 @@ class extra_field
 				case 1:
 					$text_value = ($data_value && $data_value->data_txt) ? $data_value->data_txt : '';
 					$size = ($row_data[$i]->field_size > 0) ? $row_data[$i]->field_size : 20;
-					$extra_field_value = '<input class="' . $row_data[$i]->field_class . '" type="text" maxlength="' . $row_data[$i]->field_maxlength . '" ' . $required . $reqlbl . $errormsg . ' name="' . $row_data[$i]->field_name . '"  id="' . $row_data[$i]->field_name . '" value="' . htmlspecialchars($text_value) . '" size="' . $size . '" />';
+					$extra_field_value = '<input class="' . $row_data[$i]->field_class . '" type="text" maxlength="' . $row_data[$i]->field_maxlength . '" ' . $required . $reqlbl . $errormsg . ' name="' . $row_data[$i]->field_name . '"  id="' . $row_data[$i]->field_name . '" value="' . stripslashes(htmlspecialchars($text_value)) . '" size="' . $size . '" />';
 					$ex_field .= '<td valign="top" width="100" align="right" class="key">' . $extra_field_label . '</td>';
 					$ex_field .= '<td>' . $extra_field_value;
 					break;
@@ -139,7 +139,7 @@ class extra_field
 				// 2 :- Text Area
 				case 2:
 					$textarea_value = ($data_value && $data_value->data_txt) ? $data_value->data_txt : '';
-					$extra_field_value = '<textarea class="' . $row_data[$i]->field_class . '"  name="' . $row_data[$i]->field_name . '" ' . $required . $reqlbl . $errormsg . ' id="' . $row_data[$i]->field_name . '" cols="' . $row_data[$i]->field_cols . '" rows="' . $row_data[$i]->field_rows . '" >' . htmlspecialchars($textarea_value) . '</textarea>';
+					$extra_field_value = '<textarea class="' . $row_data[$i]->field_class . '"  name="' . $row_data[$i]->field_name . '" ' . $required . $reqlbl . $errormsg . ' id="' . $row_data[$i]->field_name . '" cols="' . $row_data[$i]->field_cols . '" rows="' . $row_data[$i]->field_rows . '" >' . stripslashes(htmlspecialchars($textarea_value)) . '</textarea>';
 					$ex_field .= '<td valign="top" width="100" align="right" class="key">' . $extra_field_label . '</td>';
 					$ex_field .= '<td>' . $extra_field_value;
 					break;

--- a/component/admin/views/product/tmpl/default.php
+++ b/component/admin/views/product/tmpl/default.php
@@ -301,7 +301,7 @@ for ($i = 0, $n = count($this->products); $i < $n; $i++)
 			$field_value = '';
 			if (count($field_arr) > 0)
 			{
-				$field_value = $field_arr->data_txt;
+				$field_value = stripslashes($field_arr->data_txt);
 			}    ?>
 			<td><?php echo $field_value;  ?></td>
 		<?php }    ?>


### PR DESCRIPTION
Stripped slashes to avoid creating trailing backslashes when saving from the editor. Removed them also from the product list if the extra field is listed.
