### PR TITLE
Send Codeception errors to #redSHOP slack chat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,12 @@ before_script:
 script:
   - php .travis/traviswebserverckecker.php http://localhost/joomla-cms/installation/index.php # Test apache
   #- php .travis/phpparseerrorchecker.php component/ modules/ plugins/
-  # - phing -f .travis.xml
-  # Comment all system tests to use only Codeception
   - mv tests/acceptance.suite.dist.yml tests/acceptance.suite.yml # Create travis system tests config file
   - "wget http://codeception.com/codecept.phar"
   - php ./codecept.phar build
   - php ./codecept.phar run acceptance
-  #- mv tests/system/servers/travis.configdef.php tests/system/servers/configdef.php # Create travis system tests config file
-  #- cd tests/system/webdriver/tests/
-  #- phpunit .
+  - php .travis/codeceptionerror2slack.php # Send found errors into redSHOP slackchat
+
   
 notifications:
   slack:

--- a/.travis/codeceptionerror2slack.php
+++ b/.travis/codeceptionerror2slack.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @package     redshop1.travis
+ * @subpackage  
+ *
+ * @copyright   Copyright (C) 2005 - 2014 redCOMPONENT.com. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/*
+ * This script sends the screen captured errors found by Codeception framework into Slack chat
+ *
+ * remind to modify the following two variables if you want to use it in other projects
+ */
+$slackChannel = 'C029D9ZQL';
+$slackToken= 'xoxp-2309442657-2309442659-2680880772-1a436d';
+
+// Only run on the CLI SAPI
+(php_sapi_name() == 'cli' ?: die('CLI only'));
+
+// Script defines
+define('REPO_BASE', dirname(__DIR__));
+
+// Welcome message
+fwrite(STDOUT, "\033[32;1mCheck if there is Codeception snapshots and sending them to Slack.\033[0m\n");
+
+$codeceptionOutputFolder = REPO_BASE . '/tests/_output';
+
+if (!file_exists($codeceptionOutputFolder) || !(new \FilesystemIterator($codeceptionOutputFolder))->valid())
+{
+    fwrite(STDOUT, "\033[32;1mThere are no errors found by Codeception\033[0m\n");
+    exit(0);
+}
+
+$error = false;
+$errorSnapshot = '';
+
+// Loop throught Codeception snapshots
+if ($handler = opendir($codeceptionOutputFolder)) {
+    while (false !== ($errorSnapshot = readdir($handler))) {
+        if ('.' === $errorSnapshot) continue;
+        if ('..' === $errorSnapshot) continue;
+
+        // Sends error snapshot to Slack channel
+        $command = 'curl -F file=@' . $codeceptionOutputFolder . '/' . $errorSnapshot . ' -F '
+            . 'channels='. $slackChannel  . ' -F '
+            . 'title=Codeception_error -F '
+            . 'initial_comment="error found by travis" -F'
+            . 'token=' . $slackToken . ' '
+            . 'https://slack.com/api/files.upload';
+        //fwrite(STDOUT, $command);
+        $response = shell_exec($command);
+
+        if($response->ok)
+        {
+            fwrite(STDOUT, "\033[31;1mAn error image was sent to slack\033[0m\n");
+        }
+        else
+        {
+            fwrite(STDOUT, "\033[32;1mSlack could not be reached\033[0m\n");
+        }
+
+        $error = true;
+    }
+    closedir($handle);
+}
+
+// Make travis fail warning that there are Errors to fix
+exit(1);
+


### PR DESCRIPTION
This code gets the "Codeception snapshots of the errors captured while testing in travis", that basically are the images stored at tests/_output/ folder. And then sends them to Slack using the Slack API: https://api.slack.com/methods/files.upload
