### PR TITLE
REDSHOP-1543, REDSHOP-1592, REDSHOP-1612 #comment performance improvement by excluding extra queries (part 2)

### DIFF
--- a/component/admin/controllers/product_detail.php
+++ b/component/admin/controllers/product_detail.php
@@ -865,7 +865,7 @@ class RedshopControllerProduct_Detail extends JController
 	{
 		$pid = $this->input->get->getInt('pid', null);
 
-		$model = $this->getModel();
+		$model = $this->getModel('product_detail');
 
 		if ($model->removepropertyImage($pid))
 		{
@@ -882,7 +882,7 @@ class RedshopControllerProduct_Detail extends JController
 	{
 		$pid = $this->input->get->getInt('pid', null);
 
-		$model = $this->getModel();
+		$model = $this->getModel('product_detail');
 
 		if ($model->removesubpropertyImage($pid))
 		{
@@ -900,7 +900,7 @@ class RedshopControllerProduct_Detail extends JController
 		// ToDo: This is potentially unsafe because $_POST elements are not sanitized.
 		$post = $this->input->getArray($_POST);
 
-		$model = $this->getModel();
+		$model = $this->getModel('product_detail');
 
 		if ($model->SaveAttributeStockroom($post))
 		{

--- a/component/admin/helpers/extra_field.php
+++ b/component/admin/helpers/extra_field.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHTML::_('behavior.tooltip');
 jimport('joomla.filesystem.file');
+JLoader::load('RedshopHelperHelper');
 
 class extra_field
 {
@@ -80,20 +81,10 @@ class extra_field
 		$url    = $uri->root();
 		$q      = "SELECT * FROM " . $this->_table_prefix . "fields WHERE field_section = " . (int) $field_section . " AND published=1 ";
 
-		if ($field_name != "")
+		if ($field_name != '')
 		{
-			$field_name = explode(',', $field_name);
-
-			$field_name = array_map(
-				function ($value) use ($db) {
-					return $db->quote($value);
-				},
-				(array) $field_name
-			);
-
-			$field_name = implode(",'", $field_name);
-
-			$q .= "AND field_name IN ($field_name) ";
+			$field_name = redhelper::quote(explode(',', $field_name));
+			$q .= 'AND field_name IN (' . implode(',', $field_name) . ') ';
 		}
 
 		$q .= " ORDER BY ordering";

--- a/component/admin/models/shipping_rate_detail.php
+++ b/component/admin/models/shipping_rate_detail.php
@@ -102,6 +102,7 @@ class RedshopModelShipping_rate_detail extends JModel
 			$detail->shipping_rate_on_shopper_group = null;
 			$detail->economic_displaynumber = null;
 			$detail->deliver_type = null;
+			$detail->consignor_carrier_code = null;
 			$this->_data = $detail;
 
 			return (boolean) $this->_data;

--- a/component/admin/models/update.php
+++ b/component/admin/models/update.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 jimport('joomla.application.component.model');
 JLoader::load('RedshopHelperAdminUpdate');
+JLoader::load('RedshopHelperHelper');
 
 /**
  * Class RedshopModelUpdate
@@ -170,7 +171,7 @@ class RedshopModelUpdate extends JModelLegacy
 						{
 							if (!$this->checkIndex($tableName, $key))
 							{
-								$indexFields = implode(',', self::quote((array) $oneIndex, 'qn'));
+								$indexFields = implode(',', redhelper::quote((array) $oneIndex, 'qn'));
 								$db->setQuery('ALTER TABLE ' . $db->qn($tableName) . ' ADD INDEX ' . $db->qn($key) . ' (' . $indexFields . ')');
 
 								if (!$db->execute())
@@ -200,7 +201,7 @@ class RedshopModelUpdate extends JModelLegacy
 						{
 							if (!$this->checkIndex($tableName, $key))
 							{
-								$indexFields = implode(',', self::quote((array) $oneIndex, 'qn'));
+								$indexFields = implode(',', redhelper::quote((array) $oneIndex, 'qn'));
 								$db->setQuery('ALTER TABLE ' . $db->qn($tableName) . ' ADD UNIQUE ' . $db->qn($key) . ' (' . $indexFields . ')');
 
 								if (!$db->execute())

--- a/component/admin/models/update.php
+++ b/component/admin/models/update.php
@@ -253,24 +253,4 @@ class RedshopModelUpdate extends JModelLegacy
 			return array('success' => true);
 		}
 	}
-
-	/**
-	 * Quote an array of values.
-	 *
-	 * @param   array   $values     The values.
-	 * @param   string  $nameQuote  Name quote
-	 *
-	 * @return  array  The quoted values
-	 */
-	public static function quote(array $values, $nameQuote = 'q')
-	{
-		$db = JFactory::getDbo();
-
-		return array_map(
-			function ($value) use ($db, $nameQuote) {
-				return $db->$nameQuote($value);
-			},
-			$values
-		);
-	}
 }

--- a/component/site/controllers/search.php
+++ b/component/site/controllers/search.php
@@ -42,7 +42,7 @@ class RedshopControllerSearch extends JController
 		$get = JRequest::get('get');
 		$taskid = $get['taskid'];
 
-		$model = $this->getModel();
+		$model = $this->getModel('search');
 
 		$brands = $model->loadCatProductsManufacturer($taskid);
 

--- a/component/site/helpers/helper.php
+++ b/component/site/helpers/helper.php
@@ -28,6 +28,26 @@ class redhelper
 	}
 
 	/**
+	 * Quote an array of values.
+	 *
+	 * @param   array   $values     The values.
+	 * @param   string  $nameQuote  Name quote, can be possible q, quote, qn, quoteName
+	 *
+	 * @return  array  The quoted values
+	 */
+	public static function quote(array $values, $nameQuote = 'q')
+	{
+		$db = JFactory::getDbo();
+
+		return array_map(
+			function ($value) use ($db, $nameQuote) {
+				return $db->$nameQuote($value);
+			},
+			$values
+		);
+	}
+
+	/**
 	 * Get Redshop Menu Items
 	 *
 	 * @return array

--- a/component/site/helpers/product.php
+++ b/component/site/helpers/product.php
@@ -90,6 +90,107 @@ class producthelper
 	}
 
 	/**
+	 * Get Main Product Query
+	 *
+	 * @param   bool|JDatabaseQuery  $query   Get query or false
+	 * @param   int                  $userId  User id
+	 *
+	 * @return JDatabaseQuery
+	 */
+	public function getMainProductQuery($query = false, $userId = 0)
+	{
+		$shopperGroupId = $this->_userhelper->getShopperGroup($userId);
+		$db = JFactory::getDbo();
+
+		if (!$query)
+		{
+			$query = $db->getQuery(true);
+		}
+
+		$query->select(array('p.*', 'p.product_id'))
+			->from($db->qn('#__redshop_product', 'p'));
+
+		// Require condition
+		$query->group('p.product_id');
+
+		// Select price
+		$query->select(
+			array(
+				'pp.price_id', $db->qn('pp.product_price', 'price_product_price'),
+				$db->qn('pp.product_currency', 'price_product_currency'), $db->qn('pp.discount_price', 'price_discount_price'),
+				$db->qn('pp.discount_start_date', 'price_discount_start_date'), $db->qn('pp.discount_end_date', 'price_discount_end_date')
+			)
+		)
+			->leftJoin(
+				$db->qn('#__redshop_product_price', 'pp')
+				. ' ON p.product_id = pp.product_id AND ((pp.price_quantity_start <= 1 AND pp.price_quantity_end >= 1) OR (pp.price_quantity_start = 0 AND pp.price_quantity_end = 0)) AND pp.shopper_group_id = ' . (int) $shopperGroupId
+			)
+			->order('pp.price_quantity_start ASC');
+
+		// Select category
+		$query->select(array('pc.category_id'))
+			->leftJoin($db->qn('#__redshop_product_category_xref', 'pc') . ' ON pc.product_id = p.product_id');
+
+		// Select media
+		$query->select(array('media.media_alternate_text', 'media.media_id'))
+			->leftJoin(
+				$db->qn('#__redshop_media', 'media')
+				. ' ON media.section_id = p.product_id AND media.media_section = ' . $db->q('product')
+				. ' AND media.media_type = ' . $db->q('images') . ' AND media.media_name = p.product_full_image'
+			);
+
+		// Select ratings
+		$subQuery = $db->getQuery(true)
+			->select('COUNT(pr1.rating_id)')
+			->from($db->qn('#__redshop_product_rating', 'pr1'))
+			->where('pr1.product_id = p.product_id')
+			->where('pr1.published = 1');
+
+		$query->select('(' . $subQuery . ') AS count_rating');
+
+		$subQuery = $db->getQuery(true)
+			->select('SUM(pr2.user_rating)')
+			->from($db->qn('#__redshop_product_rating', 'pr2'))
+			->where('pr2.product_id = p.product_id')
+			->where('pr2.published = 1');
+
+		$query->select('(' . $subQuery . ') AS sum_rating');
+
+		// Count Accessories
+		$subQuery = $db->getQuery(true)
+			->select('COUNT(pa.accessory_id)')
+			->from($db->qn('#__redshop_product_accessory', 'pa'))
+			->leftJoin($db->qn('#__redshop_product', 'parent_product') . ' ON parent_product.product_id = pa.child_product_id')
+			->where('pa.product_id = p.product_id')
+			->where('parent_product.published = 1');
+
+		$query->select('(' . $subQuery . ') AS total_accessories');
+
+		// Count child products
+		$subQuery = $db->getQuery(true)
+			->select('COUNT(child.product_id)')
+			->from($db->qn('#__redshop_product', 'child'))
+			->where('child.product_parent_id = p.product_id')
+			->where('child.published = 1');
+
+		$query->select('(' . $subQuery . ') AS count_child_products');
+
+		// Sum quantity
+		if (USE_STOCKROOM == 1)
+		{
+			$subQuery = $db->getQuery(true)
+				->select('SUM(psx.quantity)')
+				->from($db->qn('#__redshop_product_stockroom_xref', 'psx'))
+				->where('psx.product_id = p.product_id')
+				->where('psx.quantity >= 0');
+
+			$query->select('(' . $subQuery . ') AS sum_quanity');
+		}
+
+		return $query;
+	}
+
+	/**
 	 * Get product information
 	 *
 	 * @param   int  $productId  Product id
@@ -107,73 +208,18 @@ class producthelper
 
 		if (!array_key_exists($productId . '.' . $userId, self::$products))
 		{
-			$shopperGroupId = $this->_userhelper->getShopperGroup($userId);
 			$db = JFactory::getDbo();
-			$query = $db->getQuery(true);
+			$query = $this->getMainProductQuery(false, $userId);
 
 			// Select product
-			$query->select(array('p.*'))
-				->from($db->qn('#__redshop_product', 'p'))
-				->where($db->qn('p.product_id') . ' = ' . (int) $productId);
-
-			// Require condition
-			$query->group('p.product_id');
-
-			// Select price
-			$query->select(
-					array(
-						'pp.price_id', $db->qn('pp.product_price', 'price_product_price'),
-						$db->qn('pp.product_currency', 'price_product_currency'), $db->qn('pp.discount_price', 'price_discount_price'),
-						$db->qn('pp.discount_start_date', 'price_discount_start_date'), $db->qn('pp.discount_end_date', 'price_discount_end_date')
-					)
-				)
-				->leftJoin(
-					$db->qn('#__redshop_product_price', 'pp')
-					. ' ON p.product_id = pp.product_id AND ((pp.price_quantity_start <= 1 AND pp.price_quantity_end >= 1) OR (pp.price_quantity_start = 0 AND pp.price_quantity_end = 0)) AND pp.shopper_group_id = ' . (int) $shopperGroupId
-				)
-				->order('pp.price_quantity_start ASC');
-
-			// Select category
-			$query->select(array('pcx.category_id'))
-				->leftJoin($db->qn('#__redshop_product_category_xref', 'pcx') . ' ON pcx.product_id = p.product_id');
-
-			// Select media
-			$query->select(array('media.media_alternate_text', 'media.media_id'))
-				->leftJoin(
-					$db->qn('#__redshop_media', 'media')
-					. ' ON media.section_id = p.product_id AND media.media_section = ' . $db->q('product')
-					. ' AND media.media_type = ' . $db->q('images') . ' AND media.media_name = p.product_full_image'
-				);
-
-			// Select ratings
-			$subQuery = $db->getQuery(true)
-				->select('COUNT(pr1.rating_id)')
-				->from($db->qn('#__redshop_product_rating', 'pr1'))
-				->where('pr1.product_id = p.product_id')
-				->where('pr1.published = 1');
-
-			$query->select('(' . $subQuery . ') AS count_rating');
-
-			$subQuery = $db->getQuery(true)
-				->select('SUM(pr2.user_rating)')
-				->from($db->qn('#__redshop_product_rating', 'pr2'))
-				->where('pr2.product_id = p.product_id')
-				->where('pr2.published = 1');
-
-			$query->select('(' . $subQuery . ') AS sum_rating');
-
-			// Count Accessories
-			$subQuery = $db->getQuery(true)
-				->select('COUNT(pa.accessory_id)')
-				->from($db->qn('#__redshop_product_accessory', 'pa'))
-				->leftJoin($db->qn('#__redshop_product', 'parent_product') . ' ON parent_product.product_id = pa.child_product_id')
-				->where('pa.product_id = p.product_id')
-				->where('parent_product.published = 1');
-
-			$query->select('(' . $subQuery . ') AS total_accessories');
+			$query->where($db->qn('p.product_id') . ' = ' . (int) $productId);
 
 			$db->setQuery($query);
-			self::$products[$productId . '.' . $userId] = $db->loadObject();
+
+			if (self::$products[$productId . '.' . $userId] = $db->loadObject())
+			{
+				$this->setAttributes(array($productId . '.' . $userId => self::$products[$productId . '.' . $userId]), $userId);
+			}
 		}
 
 		return self::$products[$productId . '.' . $userId];
@@ -189,6 +235,76 @@ class producthelper
 	public function setProduct($products)
 	{
 		self::$products = $products + self::$products;
+		$this->setAttributes($products);
+	}
+
+	/**
+	 * Set Attributes and properties
+	 *
+	 * @param   array  $products  Products
+	 * @param   int    $userId    User id
+	 *
+	 * @return  void
+	 */
+	public function setAttributes($products, $userId = 0)
+	{
+		if (!$userId)
+		{
+			$user = JFactory::getUser();
+			$userId = $user->id;
+		}
+
+		$keys = array();
+
+		foreach ((array) $products  as $product)
+		{
+			$keys[] = $product->product_id;
+			self::$products[$product->product_id . '.' . $userId]->attributes = array();
+		}
+
+		if (count($keys) > 0)
+		{
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select(array('a.attribute_id AS value', 'a.attribute_name AS text', 'a.*', 'ast.attribute_set_name', 'ast.published AS attribute_set_published'))
+				->from($db->qn('#__redshop_product_attribute', 'a'))
+				->leftJoin($db->qn('#__redshop_attribute_set', 'ast') . ' ON ast.attribute_set_id = a.attribute_set_id')
+				->where('a.attribute_name != ' . $db->q(''))
+				->where('a.attribute_published = 1')
+				->where('a.product_id IN (' . implode(',', $keys) . ')')
+				->order('a.ordering ASC');
+			$db->setQuery($query);
+
+			if ($results = $db->loadObjectList())
+			{
+				foreach ($results as $result)
+				{
+					self::$products[$result->product_id . '.' . $userId]->attributes[$result->attribute_id] = $result;
+					self::$products[$result->product_id . '.' . $userId]->attributes[$result->attribute_id]->properties = array();
+				}
+
+				$query->clear()
+					->select(
+						array('ap.property_id AS value', 'ap.property_name AS text', 'ap.*', 'a.attribute_name', 'a.attribute_id', 'a.product_id', 'a.attribute_set_id')
+					)
+					->from($db->qn('#__redshop_product_attribute_property', 'ap'))
+					->leftJoin($db->qn('#__redshop_product_attribute', 'a') . ' ON a.attribute_id = ap.attribute_id')
+					->where('a.product_id IN (' . implode(',', $keys) . ')')
+					->where('ap.property_published = 1')
+					->where('a.attribute_published = 1')
+					->where('a.attribute_name != ' . $db->q(''))
+					->order('ap.ordering ASC');
+				$db->setQuery($query);
+
+				if ($results = $db->loadObjectList())
+				{
+					foreach ($results as $result)
+					{
+						self::$products[$result->product_id . '.' . $userId]->attributes[$result->attribute_id]->properties[$result->property_id] = $result;
+					}
+				}
+			}
+		}
 	}
 
 	public function country_in_eu_common_vat_zone($country)
@@ -846,14 +962,11 @@ class producthelper
 			}
 		}
 
-		$dbname = "";
-
 		if (count($str) > 0)
 		{
-			$dbname = "'" . implode("','", $str) . "'";
+			$dbname = implode(',', redhelper::quote($str));
+			$template_data = $extraField->extra_field_display($section, $product_id, $dbname, $template_data, $categorypage);
 		}
-
-		$template_data = $extraField->extra_field_display($section, $product_id, $dbname, $template_data, $categorypage);
 
 		return $template_data;
 	}
@@ -3403,122 +3516,241 @@ class producthelper
 		return;
 	}
 
-	public function getProductAttribute($product_id = 0, $attribute_set_id = 0, $attribute_id = 0, $published = 0, $attribute_required = 0, $notAttributeId = 0)
+	/**
+	 * Get Product Attribute
+	 *
+	 * @param   int  $productId          Product id
+	 * @param   int  $attributeSetId     Attribute set id
+	 * @param   int  $attributeId        Attribute id
+	 * @param   int  $published          Published attribute set
+	 * @param   int  $attributeRequired  Attribute required
+	 * @param   int  $notAttributeId     Not attribute id
+	 *
+	 * @return mixed
+	 */
+	public function getProductAttribute($productId = 0, $attributeSetId = 0, $attributeId = 0, $published = 0, $attributeRequired = 0, $notAttributeId = 0)
 	{
-		$and          = "";
-		$astpublished = "";
-
-		if ($product_id != 0)
+		if ($productId)
 		{
-			$and .= "AND a.product_id IN (" . (int) $product_id . ") ";
-		}
+			$selectedAttributes = array();
+			$productData = $this->getProductById($productId);
 
-		if ($attribute_set_id != 0)
+			if ($productData && isset($productData->attributes))
+			{
+				foreach ($productData->attributes as $attribute)
+				{
+					if (($attributeSetId && $attributeSetId != $attribute->attribute_set_id)
+						|| ($attributeId && $attributeId != $attribute->attribute_id)
+						|| ($published && $published != $attribute->attribute_set_published)
+						|| ($attributeRequired && $attributeRequired != $attribute->attribute_required))
+					{
+						continue;
+					}
+
+					if ($notAttributeId)
+					{
+						$notAttributeIds = explode(',', $notAttributeId);
+						JArrayHelper::toInteger($notAttributeIds);
+
+						if (in_array($attribute->attribute_id, $notAttributeIds))
+						{
+							continue;
+						}
+					}
+
+					$selectedAttributes[] = $attribute;
+				}
+			}
+
+			return $selectedAttributes;
+		}
+		else
 		{
-			$and .= "AND a.attribute_set_id = " . (int) $attribute_set_id . " ";
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select(array('a.attribute_id AS value', 'a.attribute_name AS text', 'a.*', 'ast.attribute_set_name'))
+				->from($db->qn('#__redshop_product_attribute', 'a'))
+				->leftJoin($db->qn('#__redshop_attribute_set', 'ast') . ' ON ast.attribute_set_id = a.attribute_set_id')
+				->where('a.attribute_name != ' . $db->q(''))
+				->where('a.attribute_published = 1')
+				->order('a.ordering ASC');
+
+			if ($attributeSetId != 0)
+			{
+				$query->where('a.attribute_set_id = ' . (int) $attributeSetId);
+			}
+
+			if ($attributeId != 0)
+			{
+				$query->where('a.attribute_id = ' . (int) $attributeId);
+			}
+
+			if ($published != 0)
+			{
+				$query->where('ast.published = ' . (int) $published);
+			}
+
+			if ($attributeRequired != 0)
+			{
+				$query->where('a.attribute_required = ' . (int) $attributeRequired);
+			}
+
+			if ($notAttributeId != 0)
+			{
+				// Sanitize ids
+				$notAttributeIds = explode(',', $notAttributeId);
+				JArrayHelper::toInteger($notAttributeIds);
+
+				$query->where('a.attribute_id NOT IN (' . implode(',', $notAttributeIds) . ')');
+			}
+
+			$db->setQuery($query);
+
+			return $db->loadObjectlist();
 		}
-
-		if ($attribute_id != 0)
-		{
-			$and .= "AND a.attribute_id = " . (int) $attribute_id . " ";
-		}
-
-		if ($published != 0)
-		{
-			$astpublished = " AND ast.published = " . (int) $published . " ";
-		}
-
-		if ($attribute_required != 0)
-		{
-			$and .= "AND a.attribute_required = " . (int) $attribute_required . " ";
-		}
-
-		if ($notAttributeId != 0)
-		{
-			// Sanitize ids
-			$notAttributeIds = explode(',', $notAttributeId);
-			JArrayHelper::toInteger($notAttributeIds);
-
-			$and .= "AND a.attribute_id NOT IN (" . implode(',', $notAttributeIds) . ") ";
-		}
-
-		$query = "SELECT a.attribute_id AS value,a.attribute_name AS text,a.*,ast.attribute_set_name "
-			. "FROM " . $this->_table_prefix . "product_attribute AS a "
-			. "LEFT JOIN " . $this->_table_prefix . "attribute_set AS ast ON ast.attribute_set_id=a.attribute_set_id "
-			. $astpublished
-			. "WHERE a.attribute_name!='' "
-			. $and
-			. " and attribute_published=1 ORDER BY a.ordering ASC ";
-		$this->_db->setQuery($query);
-		$list = $this->_db->loadObjectlist();
-
-		return $list;
 	}
 
-	public function getAttibuteProperty($property_id = 0, $attribute_id = 0, $product_id = 0, $attribute_set_id = 0, $required = 0, $notPropertyId = 0)
+	/**
+	 * Get Attribute Property
+	 *
+	 * @param   int  $propertyId      Property id
+	 * @param   int  $attributeId     Attribute id
+	 * @param   int  $productId       Product id
+	 * @param   int  $attributeSetId  Attribute set id
+	 * @param   int  $required        Required
+	 * @param   int  $notPropertyId   Not property id
+	 *
+	 * @return  mixed
+	 */
+	public function getAttibuteProperty($propertyId = 0, $attributeId = 0, $productId = 0, $attributeSetId = 0, $required = 0, $notPropertyId = 0)
 	{
-		$and = "";
-
-		if ($attribute_id != 0)
+		if ($productId)
 		{
-			// Sanitize ids
-			$attributeIds = explode(',', $attribute_id);
-			JArrayHelper::toInteger($attributeIds);
+			$selectedProperties = array();
+			$productId = explode(',', $productId);
+			JArrayHelper::toInteger($productId);
 
-			$and .= "AND ap.attribute_id IN (" . implode(',', $attributeIds) . ") ";
+			if ($attributeId)
+			{
+				$attributeId = explode(',', $attributeId);
+				JArrayHelper::toInteger($attributeId);
+			}
+
+			foreach ($productId as $item)
+			{
+				if ($productData = $this->getProductById($item))
+				{
+					foreach ($productData->attributes as $attribute)
+					{
+						if ($attributeId && !in_array($attribute->attribute_id, $attributeId))
+						{
+							continue;
+						}
+
+						foreach ($attribute->properties as $property)
+						{
+							if ($propertyId)
+							{
+								$propertyIds = explode(',', $propertyId);
+								JArrayHelper::toInteger($propertyIds);
+
+								if (!in_array($property->property_id, $propertyIds))
+								{
+									continue;
+								}
+							}
+
+							if ($attributeSetId)
+							{
+								$attributeSetIds = explode(',', $attributeSetId);
+								JArrayHelper::toInteger($attributeSetIds);
+
+								if (!in_array($property->attribute_set_id, $attributeSetIds))
+								{
+									continue;
+								}
+							}
+
+							if ($required && $required != $property->setrequire_selected)
+							{
+								continue;
+							}
+
+							if ($notPropertyId)
+							{
+								$notPropertyIds = explode(',', $notPropertyId);
+								JArrayHelper::toInteger($notPropertyIds);
+
+								if (in_array($property->property_id, $notPropertyIds))
+								{
+									continue;
+								}
+							}
+
+							$selectedProperties[] = $property;
+						}
+					}
+				}
+			}
+
+			return $selectedProperties;
 		}
-
-		if ($attribute_set_id != 0)
+		else
 		{
-			// Sanitize ids
-			$attributeSetIds = explode(',', $attribute_set_id);
-			JArrayHelper::toInteger($attributeSetIds);
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select(array('ap.property_id AS value', 'ap.property_name AS text', 'ap.*', 'a.attribute_name'))
+				->from($db->qn('#__redshop_product_attribute_property', 'ap'))
+				->leftJoin($db->qn('#__redshop_product_attribute', 'a') . ' ON a.attribute_id = ap.attribute_id')
+				->where('ap.property_published = 1')
+				->order('ap.ordering ASC');
 
-			$and .= "AND a.attribute_set_id IN (" . implode(',', $attributeSetIds) . ") ";
+			if ($attributeId != 0)
+			{
+				// Sanitize ids
+				$attributeIds = explode(',', $attributeId);
+				JArrayHelper::toInteger($attributeIds);
+
+				$query->where('ap.attribute_id IN (' . implode(',', $attributeIds) . ')');
+			}
+
+			if ($attributeSetId != 0)
+			{
+				// Sanitize ids
+				$attributeSetIds = explode(',', $attributeSetId);
+				JArrayHelper::toInteger($attributeSetIds);
+
+				$query->where('a.attribute_set_id IN (' . implode(',', $attributeSetIds) . ')');
+			}
+
+			if ($propertyId != 0)
+			{
+				// Sanitize ids
+				$propertyIds = explode(',', $propertyId);
+				JArrayHelper::toInteger($propertyIds);
+
+				$query->where('ap.property_id IN (' . implode(',', $propertyIds) . ')');
+			}
+
+			if ($required != 0)
+			{
+				$query->where('ap.setrequire_selected = ' . (int) $required);
+			}
+
+			if ($notPropertyId != 0)
+			{
+				// Sanitize ids
+				$notPropertyIds = explode(',', $notPropertyId);
+				JArrayHelper::toInteger($notPropertyIds);
+
+				$query->where('ap.property_id NOT IN (' . implode(',', $notPropertyIds) . ')');
+			}
+
+			$db->setQuery($query);
+			$list = $db->loadObjectlist();
+
+			return $list;
 		}
-
-		if ($property_id != 0)
-		{
-			// Sanitize ids
-			$propertyIds = explode(',', $property_id);
-			JArrayHelper::toInteger($propertyIds);
-
-			$and .= "AND ap.property_id IN (" . implode(',', $propertyIds) . ") ";
-		}
-
-		if ($product_id != 0)
-		{
-			// Sanitize ids
-			$productIds = explode(',', $product_id);
-			JArrayHelper::toInteger($productIds);
-
-			$and .= "AND a.product_id IN (" . implode(',', $productIds) . ") ";
-		}
-
-		if ($required != 0)
-		{
-			$and .= "AND ap.setrequire_selected = " . (int) $required . " ";
-		}
-
-		if ($notPropertyId != 0)
-		{
-			// Sanitize ids
-			$notPropertyIds = explode(',', $notPropertyId);
-			JArrayHelper::toInteger($notPropertyIds);
-
-			$and .= "AND ap.property_id NOT IN (" . implode(',', $notPropertyIds) . ") ";
-		}
-
-		$query = "SELECT ap.property_id AS value,ap.property_name AS text,ap.*, a.attribute_name "
-			. "FROM " . $this->_table_prefix . "product_attribute_property AS ap "
-			. "LEFT JOIN " . $this->_table_prefix . "product_attribute AS a ON a.attribute_id = ap.attribute_id "
-			. "WHERE ap.property_published = 1 "
-			. $and
-			. "ORDER BY ap.ordering ASC ";
-		$this->_db->setQuery($query);
-		$list = $this->_db->loadObjectlist();
-
-		return $list;
 	}
 
 	public function getAttibutePropertyWithStock($property)
@@ -6540,7 +6772,7 @@ class producthelper
 				for ($a = 0; $a < count($attributes); $a++)
 				{
 					$selectedId = array();
-					$property   = $this->getAttibuteProperty(0, $attributes[$a]->attribute_id);
+					$property   = $this->getAttibuteProperty(0, $attributes[$a]->attribute_id, $product_id);
 
 					if ($attributes[$a]->text != "" && count($property) > 0)
 					{

--- a/component/site/models/search.php
+++ b/component/site/models/search.php
@@ -121,7 +121,7 @@ class RedshopModelSearch extends JModel
 			{
 				if (strstr($template[0]->template_desc, "{show_all_products_in_category}"))
 				{
-					$this->_data = $this->_getList($query);
+					$this->_db->setQuery($query);
 				}
 				elseif (strstr($template[0]->template_desc, "{pagination}"))
 				{
@@ -140,20 +140,27 @@ class RedshopModelSearch extends JModel
 						$this->setState('limit', $limit);
 					}
 
-					$this->_data = $this->_getList($query, $this->getState('limitstart'), $this->getState('limit'));
+					$this->_db->setQuery($query, $this->getState('limitstart'), $this->getState('limit'));
 				}
 				elseif ($this->getState('productlimit') > 0)
 				{
-					$this->_data = $this->_getList($query, $this->getState('limitstart'), $this->getState('productlimit'));
+					$this->_db->setQuery($query, $this->getState('limitstart'), $this->getState('limit'));
 				}
 				else
 				{
-					$this->_data = $this->_getList($query);
+					$this->_db->setQuery($query);
 				}
 			}
 			else
 			{
-				$this->_data = $this->_getList($query);
+				$this->_db->setQuery($query);
+			}
+
+			if ($this->_data = $this->_db->loadObjectList('concat_id'))
+			{
+				$productHelper = new producthelper;
+				$productHelper->setProduct($this->_data);
+				$this->_data = array_values($this->_data);
 			}
 		}
 
@@ -214,16 +221,13 @@ class RedshopModelSearch extends JModel
 	public function getTotal()
 	{
 		$app = JFactory::getApplication();
-		$context      = 'search';
 		$productlimit = $this->getstate('productlimit');
-
-		$layout = JRequest::getCmd('layout', 'default');
+		$layout = $app->input->getCmd('layout', 'default');
 
 		if (empty($this->_total))
 		{
-			$query = $this->_buildQuery();
-
-			$this->_total = $this->_getListCount($query);
+			$this->_db->setQuery($this->_buildQuery(0, true));
+			$this->_total = $this->_db->loadResult();
 
 			if ($layout == 'newproduct' || $layout == 'productonsale')
 			{
@@ -247,77 +251,46 @@ class RedshopModelSearch extends JModel
 		return $this->_pagination;
 	}
 
-	public function _buildQuery($manudata = 0)
+	/**
+	 * Get Search Condition
+	 *
+	 * @param   array|string  $fields      Fields
+	 * @param   array|string  $conditions  Conditions
+	 * @param   string        $glue        Glue
+	 *
+	 * @return  string
+	 */
+	public function getSearchCondition($fields, $conditions, $glue = 'OR')
+	{
+		$where = array();
+		$db = JFactory::getDbo();
+
+		foreach ((array) $fields as $field)
+		{
+			foreach ((array) $conditions as $condition)
+			{
+				$where[] = $db->qn($field) . ' LIKE ' . $db->quote('%' . $condition . '%');
+			}
+		}
+
+		return '(' . implode(' ' . $glue . ' ', $where) . ')';
+	}
+
+	/**
+	 * Build query
+	 *
+	 * @param   int|array  $manudata  Post request
+	 * @param   bool       $getTotal  Get total product(true) or product data(false)
+	 *
+	 * @return JDatabaseQuery
+	 */
+	public function _buildQuery($manudata = 0, $getTotal = false)
 	{
 		$app = JFactory::getApplication();
 		$context = 'search';
 		$db = JFactory::getDbo();
-
-		$keyword = $app->getUserStateFromRequest($context . 'keyword', 'keyword', '');
-
-		$defaultSearchType = JRequest::getCmd('search_type', 'product_name');
-
-		if (!empty($manudata['search_type']))
-		{
-			$defaultSearchType     = $manudata['search_type'];
-			$defaultSearchType_tmp = $manudata['search_type'];
-		}
-
-		if ($defaultSearchType == "name_number")
-		{
-			$defaultSearchField = "name_number";
-			$defaultSearchType  = '(p.product_name LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR p.product_number LIKE ' . $db->quote('%' . $keyword . '%') . ')';
-		}
-		elseif ($defaultSearchType == "name_desc")
-		{
-			$defaultSearchField = "name_desc";
-			$defaultSearchType  = '(p.product_name LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR p.product_desc LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR  p.product_s_desc LIKE '
-				. $db->quote('%' . $keyword . '%') . ')';
-		}
-		elseif ($defaultSearchType == "virtual_product_num")
-		{
-			$defaultSearchField = "virtual_product_num";
-			$defaultSearchType  = '(pa.property_number LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR  ps.subattribute_color_number LIKE '
-				. $db->quote('%' . $keyword . '%') . ')';
-		}
-		elseif ($defaultSearchType == "name_number_desc")
-		{
-			$defaultSearchType = '(p.product_name LIKE ' . $db->quote('%' . $keyword . '%') . ' OR p.product_number LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR p.product_desc LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR  p.product_s_desc LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR  pa.property_number LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR  ps.subattribute_color_number LIKE '
-				. $db->quote('%' . $keyword . '%') . ')';
-		}
-		elseif ($defaultSearchType == "product_desc")
-		{
-			$defaultSearchField = $defaultSearchType;
-			$defaultSearchType  = '(p.' . $defaultSearchType . ' LIKE '
-				. $db->quote('%' . $keyword . '%') . ' OR  p.product_s_desc LIKE ' . $db->quote('%' . $keyword . '%') . ' )';
-		}
-		elseif ($defaultSearchType == "product_name")
-		{
-			$main_sp_name = explode(" ", $keyword);
-
-			$defaultSearchField = $defaultSearchType;
-
-			for ($f = 0; $f < count($main_sp_name); $f++)
-			{
-				$defaultSearchType1[] = " p.product_name LIKE " . $db->quote('%' . $main_sp_name[$f] . '%');
-			}
-
-			$defaultSearchType = "(" . implode("AND", $defaultSearchType1) . ")";
-		}
-		elseif ($defaultSearchType == "product_number")
-		{
-			$defaultSearchField = $defaultSearchType;
-			$defaultSearchType  = '(p.product_number LIKE ' . $db->quote('%' . $keyword . '%') . ')';
-		}
-
+		$user = JFactory::getUser();
+		$productHelper   = new producthelper;
 		$redconfig  = $app->getParams();
 		$getorderby = urldecode(JRequest::getCmd('order_by', ''));
 
@@ -335,10 +308,32 @@ class RedshopModelSearch extends JModel
 			$order_by = 'p.product_id DESC';
 		}
 
+		if ($getTotal)
+		{
+			$query = $db->getQuery(true)
+				->select('COUNT(DISTINCT(p.product_id))')
+				->from($db->qn('#__redshop_product', 'p'))
+				->leftJoin($db->qn('#__redshop_product_category_xref', 'pc') . ' ON pc.product_id = p.product_id');
+		}
+		else
+		{
+			$query = $db->getQuery(true)
+				->order($db->escape($order_by));
+			$query = $productHelper->getMainProductQuery($query, $user->id)
+				->select(
+					array(
+						'm.*',
+						'CONCAT_WS(' . $db->q('.') . ', p.product_id, ' . (int) $user->id . ') AS concat_id'
+					)
+				)
+				->leftJoin($db->qn('#__redshop_manufacturer', 'm') . ' ON m.manufacturer_id = p.manufacturer_id');
+		}
+
+		$query->where('p.published = 1');
+
 		$layout = JRequest::getVar('layout', 'default');
 
 		$category_helper = new product_category;
-		$producthelper   = new producthelper;
 
 		$manufacture_id = JRequest::getInt('manufacture_id', 0);
 		$category_id    = JRequest::getInt('category_id', 0);
@@ -367,18 +362,12 @@ class RedshopModelSearch extends JModel
 			$cat_group = $category_id;
 		}
 
-		$params = JComponentHelper::getParams('com_redshop');
-
 		$menu = $app->getMenu();
 		$item = $menu->getActive();
-		$days = 0;
-
 		$days        = isset($item->query['newproduct']) ? $item->query['newproduct'] : 0;
 		$today       = date('Y-m-d H:i:s', time());
 		$days_before = date('Y-m-d H:i:s', time() - ($days * 60 * 60 * 24));
-		$aclProducts = $producthelper->loadAclProducts();
-
-		$whereaclProduct = "";
+		$aclProducts = $productHelper->loadAclProducts();
 
 		// Shopper group - choose from manufactures Start
 		$rsUserhelper               = new rsUserhelper;
@@ -390,7 +379,7 @@ class RedshopModelSearch extends JModel
 			$manufacturerIds = explode(',', $shopper_group_manufactures);
 			JArrayHelper::toInteger($manufacturerIds);
 
-			$whereaclProduct .= " AND p.manufacturer_id IN (" . implode(',', $manufacturerIds) . ") ";
+			$query->where('p.manufacturer_id IN (' . implode(',', $manufacturerIds) . ')');
 		}
 
 		// Shopper group - choose from manufactures End
@@ -400,14 +389,12 @@ class RedshopModelSearch extends JModel
 			$productIds = explode(',', $aclProducts);
 			JArrayHelper::toInteger($productIds);
 
-			$whereaclProduct .= " AND p.product_id IN (" . implode(',', $productIds) . ")  ";
+			$query->where('p.product_id IN (' . implode(',', $productIds) . ')');
 		}
 
 		if ($layout == 'productonsale')
 		{
 			$categoryid = $item->params->get('categorytemplate');
-			$cat_array  = "";
-			$left_join  = "";
 
 			if ($categoryid)
 			{
@@ -422,26 +409,20 @@ class RedshopModelSearch extends JModel
 				$cat_group_main[] = $categoryid;
 				JArrayHelper::toInteger($cat_group_main);
 
-				$cat_array = " AND pcx.category_id IN (" . implode(',', $cat_group_main) . ") AND pcx.product_id=p.product_id ";
-				$left_join = " LEFT JOIN " . $this->_table_prefix . "product_category_xref pcx ON pcx.product_id=p.product_id ";
+				$query->where('pc.category_id IN (' . implode(',', $cat_group_main) . ')');
 			}
 
-			$query = " SELECT * FROM " . $this->_table_prefix . "product AS p "
-				. $left_join
-				. "WHERE p.published = 1 "
-				. "AND p.product_on_sale=1 "
-				. "AND p.expired=0 "
-				. "AND p.product_parent_id=0 "
-				. $whereaclProduct . $cat_array
-				. " ORDER BY " . $db->escape($order_by);
+			$query->where(
+				array(
+					'p.product_on_sale = 1',
+					'p.expired = 0',
+					'p.product_parent_id = 0'
+				)
+			);
 		}
 		elseif ($layout == 'featuredproduct')
 		{
-			$query = " SELECT * FROM " . $this->_table_prefix . "product AS p "
-				. "WHERE p.published = 1 "
-				. "AND p.product_special=1 "
-				. $whereaclProduct
-				. " ORDER BY " . $db->escape($order_by);
+			$query->where('p.product_special = 1');
 		}
 		elseif ($layout == 'newproduct')
 		{
@@ -458,43 +439,78 @@ class RedshopModelSearch extends JModel
 			$cat_group_main[] = $catid;
 			JArrayHelper::toInteger($cat_group_main);
 
-			$extracond = "";
-
 			if ($catid)
 			{
-				$extracond = " AND pcx.category_id in (" . implode(',', $cat_group_main) . ") AND pcx.product_id=p.product_id ";
+				$query->where('pc.category_id in (' . implode(',', $cat_group_main) . ')');
 			}
 
-			$query = " SELECT distinct p.* "
-				. " FROM " . $this->_table_prefix . "product p "
-				. "LEFT JOIN " . $this->_table_prefix . "product_category_xref pcx ON pcx.product_id = p.product_id "
-				. "WHERE p.published = 1  "
-				. "and  p.publish_date BETWEEN " . $db->quote($days_before) . " AND " . $db->quote($today) . " AND p.expired = 0  AND p.product_parent_id = 0 "
-				. $whereaclProduct . $extracond
-				. " ORDER BY " . $db->escape($order_by);
+			$query->where('p.publish_date BETWEEN ' . $db->quote($days_before) . ' AND ' . $db->quote($today))
+				->where('p.expired = 0')
+				->where('p.product_parent_id = 0');
 		}
 		elseif ($layout == 'redfilter')
 		{
+			$query->where('p.expired = 0');
+
 			// Get products for filtering
-			$products = $this->getRedFilterProduct();
-
-			$query = " SELECT * "
-				. " FROM " . $this->_table_prefix . "product as p "
-				. "WHERE p.published = 1 AND p.expired = 0 " . $whereaclProduct;
-
-			if ($products != "")
+			if ($products = $this->getRedFilterProduct())
 			{
 				// Sanitize ids
 				$productIds = explode(',', $products);
 				JArrayHelper::toInteger($productIds);
 
-				$query .= "AND p.product_id IN ( " . implode(',', $productIds) . " )  ";
+				$query->where('p.product_id IN ( ' . implode(',', $productIds) . ')');
 			}
-
-			$query .= " ORDER BY " . $db->escape($order_by);
 		}
 		else
 		{
+			$keyword = $app->getUserStateFromRequest($context . 'keyword', 'keyword', '');
+			$defaultSearchType = $app->input->getCmd('search_type', 'product_name');
+
+			if (!empty($manudata['search_type']))
+			{
+				$defaultSearchType = $manudata['search_type'];
+			}
+
+			if ($defaultSearchType == "name_number")
+			{
+				$query->where($this->getSearchCondition(array('p.product_name', 'p.product_number', 'p.product_s_desc'), $keyword));
+			}
+			elseif ($defaultSearchType == "name_desc")
+			{
+				$query->where($this->getSearchCondition(array('p.product_name', 'p.product_desc', 'p.product_s_desc'), $keyword));
+			}
+			elseif ($defaultSearchType == "virtual_product_num")
+			{
+				$query->where($this->getSearchCondition(array('pap.property_number', 'ps.subattribute_color_number'), $keyword));
+			}
+			elseif ($defaultSearchType == "name_number_desc")
+			{
+				$query->where(
+					$this->getSearchCondition(
+						array('p.product_name', 'p.product_number', 'p.product_desc', 'p.product_s_desc', 'pap.property_number', 'ps.subattribute_color_number'),
+						$keyword
+					)
+				);
+			}
+			elseif ($defaultSearchType == "product_desc")
+			{
+				$query->where($this->getSearchCondition('p.' . $defaultSearchType, $keyword));
+			}
+			elseif ($defaultSearchType == "product_name")
+			{
+				$mainSpName = explode(' ', $keyword);
+
+				if (count($mainSpName) > 0)
+				{
+					$query->where($this->getSearchCondition('p.product_name', explode(' ', $keyword), 'AND'));
+				}
+			}
+			elseif ($defaultSearchType == "product_number")
+			{
+				$query->where($this->getSearchCondition(array('p.product_number'), $keyword));
+			}
+
 			if ($manufacture_id == 0)
 			{
 				if (!empty($manudata['manufacturer_id']))
@@ -503,22 +519,14 @@ class RedshopModelSearch extends JModel
 				}
 			}
 
-			$query = "SELECT distinct p.* "
-				. " FROM  " . $this->_table_prefix . "product as p  ";
-
-			if ($category_id != 0)
+			if ($defaultSearchType == "name_number_desc" || $defaultSearchType == "virtual_product_num")
 			{
-				$query .= " LEFT JOIN  " . $this->_table_prefix . "product_category_xref as pcx on p.product_id = pcx.product_id ";
+				$query->leftJoin($db->qn('#__redshop_product_attribute', 'a') . ' ON a.product_id = p.product_id')
+					->leftJoin($db->qn('#__redshop_product_attribute_property', 'pap') . ' ON pap.attribute_id = a.attribute_id')
+					->leftJoin($db->qn('#__redshop_product_subattribute_color', 'ps') . ' ON ps.subattribute_id = pap.property_id');
 			}
 
-			if ($defaultSearchType_tmp == "name_number_desc" || $defaultSearchType_tmp == "virtual_product_num")
-			{
-				$query .= "LEFT JOIN " . $this->_table_prefix . "product_attribute AS a ON a.product_id = p.product_id "
-					. "LEFT JOIN " . $this->_table_prefix . "product_attribute_property AS pa ON pa.attribute_id = a.attribute_id "
-					. "LEFT JOIN " . $this->_table_prefix . "product_subattribute_color AS ps ON ps.subattribute_id = pa.property_id ";
-			}
-
-			$query .= " WHERE 1=1 AND p.expired = 0  " . $whereaclProduct;
+			$query->where('p.expired = 0');
 
 			if ($category_id != 0)
 			{
@@ -526,17 +534,13 @@ class RedshopModelSearch extends JModel
 				$catIds = explode(',', $cat_group);
 				JArrayHelper::toInteger($catIds);
 
-				$query .= " AND pcx.category_id in (" . $cat_group . ")";
+				$query->where('pc.category_id IN (' . $cat_group . ')');
 			}
 
 			if ($manufacture_id != 0)
 			{
-				$query .= " AND p.manufacturer_id =" . (int) $manufacture_id;
+				$query->where('p.manufacturer_id = ' . (int) $manufacture_id);
 			}
-
-			$query .= " AND " . $defaultSearchType
-				. " AND p.published = 1"
-				. " ORDER BY " . $db->escape($order_by);
 		}
 
 		return $query;

--- a/component/site/views/category/tmpl/categoryproduct.php
+++ b/component/site/views/category/tmpl/categoryproduct.php
@@ -485,10 +485,7 @@ if (strstr($template_desc, "{category_loop_start}") && strstr($template_desc, "{
 				// Replace compare product button.
 				$prddata_add = $producthelper->replaceCompareProductsButton($product->product_id, $this->catid, $prddata_add);
 
-				if (strstr($prddata_add, "{stockroom_detail}"))
-				{
-					$prddata_add = $stockroomhelper->replaceStockroomAmountDetail($prddata_add, $product->product_id);
-				}
+				$prddata_add = $stockroomhelper->replaceStockroomAmountDetail($prddata_add, $product->product_id);
 
 				// Checking for child products.
 				$childproduct = $producthelper->getChildProduct($product->product_id);

--- a/component/site/views/category/tmpl/detail.php
+++ b/component/site/views/category/tmpl/detail.php
@@ -958,15 +958,10 @@ if (strstr($template_desc, "{product_loop_start}") && strstr($template_desc, "{p
 		// Replace compare product button
 		$data_add = $producthelper->replaceCompareProductsButton($product->product_id, $this->catid, $data_add);
 
-		if (strstr($data_add, "{stockroom_detail}"))
-		{
-			$data_add = $stockroomhelper->replaceStockroomAmountDetail($data_add, $product->product_id);
-		}
+		$data_add = $stockroomhelper->replaceStockroomAmountDetail($data_add, $product->product_id);
 
 		// Checking for child products
-		$childproduct = $producthelper->getChildProduct($product->product_id);
-
-		if (count($childproduct) > 0)
+		if ($product->count_child_products > 0)
 		{
 			if (PURCHASE_PARENT_WITH_CHILD == 1)
 			{

--- a/component/site/views/search/view.html.php
+++ b/component/site/views/search/view.html.php
@@ -126,7 +126,8 @@ class RedshopViewSearch extends JView
 		$this->templatedata = $templatedata;
 		$this->search = $search;
 		$this->pagination = $pagination;
-		$this->request_url = JFilterOutput::cleanText($uri->toString());
+		$this->request_url = $uri->toString();
+		JFilterOutput::cleanText($this->request_url);
 		parent::display($tpl);
 	}
 
@@ -359,6 +360,7 @@ class RedshopViewSearch extends JView
 			$tagarray            = $texts->getTextLibraryTagArray();
 			$data                = "";
 			$count_no_user_field = 0;
+			$fieldArray = $extraField->getSectionFieldList(17, 0, 0);
 
 			for ($i = 0; $i < count($this->search); $i++)
 			{
@@ -627,7 +629,6 @@ class RedshopViewSearch extends JView
 
 				// ProductFinderDatepicker Extra Field Start
 
-				$fieldArray = $extraField->getSectionFieldList(17, 0, 0);
 				$data_add   = $producthelper->getProductFinderDatepickerValue($data_add, $this->search[$i]->product_id, $fieldArray);
 
 				// ProductFinderDatepicker Extra Field End
@@ -639,15 +640,8 @@ class RedshopViewSearch extends JView
 
 				if ($manufacturer_id != 0)
 				{
-					$manufacturer_data      = $producthelper->getSection("manufacturer", $manufacturer_id);
 					$manufacturer_link_href = JRoute::_('index.php?option=com_redshop&view=manufacturers&layout=detail&mid=' . $manufacturer_id . '&Itemid=' . $Itemid);
-					$manufacturer_name      = "";
-
-					if (count($manufacturer_data) > 0)
-					{
-						$manufacturer_name = $manufacturer_data->manufacturer_name;
-					}
-
+					$manufacturer_name = $this->search[$i]->manufacturer_name;
 					$manufacturer_link = '<a href="' . $manufacturer_link_href . '" title="' . $manufacturer_name . '">' . $manufacturer_name . '</a>';
 
 					if (strstr($data_add, "{manufacturer_link}"))
@@ -676,9 +670,7 @@ class RedshopViewSearch extends JView
 				$data_add = $producthelper->replaceCompareProductsButton($this->search[$i]->product_id, 0, $data_add);
 
 				// Checking for child products
-				$childproduct = $producthelper->getChildProduct($this->search[$i]->product_id);
-
-				if (count($childproduct) > 0)
+				if ($this->search[$i]->count_child_products > 0)
 				{
 					$isChilds   = true;
 					$attributes = array();


### PR DESCRIPTION
- fix fatal error when in admin view product_detail try save property amount stock
- fix error in module product search, when display manufacturer in filter
- fix notice in search view, when try search some keyword 
- fix notice when try create new shipping rate
- now use in one place structure main query for select product (helper product.php function getMainProductQuery), so controlled changes now more easy. Using in category model, search model and when call function getProductById.
- small optimize for exclude extra queries in product 'extra fields'
- move queries for attributes, properties and product stock amount in main product query, so that queries excluding and redSHOP work more fast. Queries in page now ~50-60(its if use stockroom, and attributes, and properties), execute page time 0.35-0.25sec(checking in joomla debugger).
- added function 'quote' for add DB quotes for each value in array.
  @gunjanpatel please help check bugs when you have a time :)
- now unify quote functions
