### PR TITLE
REDSHOP-1354 - Notice when creating a state

### DIFF
--- a/component/admin/models/state_detail.php
+++ b/component/admin/models/state_detail.php
@@ -182,14 +182,16 @@ class RedshopModelState_detail extends JModel
 	 * Method to checkin/unlock the state_detail
 	 *
 	 * @access    public
+	 *
 	 * @return    boolean    True on success
+	 *
 	 * @since    1.5
 	 */
 	public function checkin()
 	{
 		if ($this->_id)
 		{
-			$state_detail = & $this->getTable('state_detail');
+			$state_detail = $this->getTable('state_detail');
 
 			if (!$state_detail->checkin($this->_id))
 			{


### PR DESCRIPTION
Go to redshop backend.
Go to state.
Click one you will edit.
Click on "Close"

![2014-11-18_1429](https://cloud.githubusercontent.com/assets/7931918/5088021/b3da3cf6-6f2f-11e4-803f-03ec3d41db81.png)

in php error log:
[18-Nov-2014 14:19:44 Europe/Berlin] PHP Strict Standards:  Only variables should be assigned by reference in C:\xampp\htdocs\redshop\administrator\components\com_redshop\models\state_detail.php on line 192

resolved.

@javigomez : is was fixed. but only this in error log..
