### PR TITLE
Add phing-latest to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,9 @@ Desktop.ini
 
 # Phing build script
 build.properties
+phing-latest.phar
 
-# composer
+# Composer
 composer.lock
 composer.phar
 vendor/*


### PR DESCRIPTION
PHPStorm is able to automatically download and use phing-latest.phar. To avoid this file to be added to the git repo I'm adding this clause in .gitignore
