### PR TITLE
Remove repo.dir property from PHING Scripts

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -2,5 +2,4 @@ comp.name=redshop
 www.dir=/var/www/redSHOP-1.2
 comp.version=1.4dev17
 joomla.version=2.5
-repo.dir=/wamp/www/github/redSHOP-1.2/
 package.dir=/wamp/www/github

--- a/component_packager.xml
+++ b/component_packager.xml
@@ -6,7 +6,6 @@
 <!--    Change the following variables in build.properties file          -->
 <!--            (copy variables from build.properties.dist )             -->
 <!--    - change the version in variable comp.version                    -->
-<!--    - change the source folder path in variable repo.dir             -->
 <!--    - change the package folder path in variable package.dir         -->
 <!--    - execute this PHING build file                                  -->
 <!-- ==================================================================  -->
@@ -27,7 +26,7 @@
     <!-- Folder where the redSHOP repository is located  -->
     <property
             name="extpath"
-            value="${repo.dir}"
+            value="${project.basedir}"
             override="true" />
 
     <!-- Target dir where packages will be created  -->
@@ -47,8 +46,9 @@
     <!-- ============================================  -->
     <target name="prepare">
         <!-- Check if the target folder exists. If not, create it -->
+        <available file="${targetdir}" type="dir" property="target_dir_exist" value="true" />
         <if>
-            <available file="${targetdir}" type="dir" />
+            <equals arg1="${target_dir_exist}" arg2="true" />
             <then>
                 <echo msg="Removing old ${targetdir}" />
                 <delete dir="${targetdir}" />

--- a/modules_packager.xml
+++ b/modules_packager.xml
@@ -6,7 +6,6 @@
 <!--    Change the following variables in build.properties file          -->
 <!--            (copy variables from build.properties.dist )             -->
 <!--    - change the version in variable comp.version                    -->
-<!--    - change the source folder path in variable repo.dir             -->
 <!--    - change the package folder path in variable package.dir         -->
 <!--    - execute this PHING build file                                  -->
 <!-- ==================================================================  -->
@@ -19,7 +18,7 @@
 	<!-- Folder where the redSHOP repository modules are located  -->
 	<property
 			name="extpath"
-			value="${repo.dir}/modules/"
+			value="${project.basedir}/modules/"
 			override="true" />
 
 	 <!-- Version of the redSHOP for witch the module is intended to  -->

--- a/plugins_packager.xml
+++ b/plugins_packager.xml
@@ -6,7 +6,6 @@
 <!--    Change the following variables in build.properties file          -->
 <!--            (copy variables from build.properties.dist )             -->
 <!--    - change the version in variable comp.version                    -->
-<!--    - change the source folder path in variable repo.dir             -->
 <!--    - change the package folder path in variable package.dir         -->
 <!--    - execute this PHING build file                                  -->
 <!-- ==================================================================  -->


### PR DESCRIPTION
We were using repo.dir property but is not necessary because PHING already provides with the constant ${project.basedir} that returns the path of the current PHING script
