### PR TITLE
REDSHOP-1863 Config Retail contries show as tags all selected in general...

### DIFF
--- a/component/admin/views/configuration/view.html.php
+++ b/component/admin/views/configuration/view.html.php
@@ -266,7 +266,7 @@ class RedshopViewConfiguration extends RedshopView
 		$lists['my_wishlist']                   = JHTML::_('select.booleanlist', 'my_wishlist', 'class="inputbox" size="1"', MY_WISHLIST);
 		$lists['compare_products']              = JHTML::_('select.booleanlist', 'compare_products', 'class="inputbox" size="1"', COMARE_PRODUCTS);
 		$lists['country_list']                  = JHTML::_('select.genericlist', $countries, 'country_list[]', 'class="inputbox" multiple="multiple"',
-			'value', 'text', $country_list
+			'value', 'text', COUNTRY_LIST
 		);
 		$lists['product_detail_is_lightbox']    = JHTML::_('select.booleanlist', 'product_detail_is_lightbox',
 			'class="inputbox" size="1"', PRODUCT_DETAIL_IS_LIGHTBOX


### PR DESCRIPTION
... tab

I am not sure this is the correct approach, but it did solve the problem of all contries selected as tags in j3, and now is empty by default and let you select multiple by holding CTRL as supposed.
Perhaps it is more a visible "problem" than an issue, when all might have been selected by default before which looks weird in j3 huge list of tags.
When writing this I realise it may be a change in behaviour where all were selected before, and this change to none selected. So maybe this issue shouldn´t be solved afterall?
