### PR TITLE
STICKERS-56 # Print order + Invoice - Create absolute url for images

### DIFF
--- a/component/admin/helpers/mail.php
+++ b/component/admin/helpers/mail.php
@@ -524,6 +524,8 @@ class redshopMail
 
 			$message = $this->_carthelper->replaceOrderTemplate($OrdersDetail, $message);
 
+			$message = $this->imginmail($message);
+
 			$pdfObj->AddPage();
 			$pdfObj->WriteHTML($message, true, false, true, false, '');
 		}


### PR DESCRIPTION
When print a order to pdf in order list. The images on the print_order template isn't created a absolute url and tcpdf is error "Can't find image/image.png"

Edit a print_order tempate and add a image with relative url
![1](https://cloud.githubusercontent.com/assets/2959010/5796906/1854a610-9fe3-11e4-91d1-f029dd37f34b.png)

Then Print Multiple Orders 
![2](https://cloud.githubusercontent.com/assets/2959010/5796907/1855d3dc-9fe3-11e4-8774-9b1d231a3c39.png)

![3](https://cloud.githubusercontent.com/assets/2959010/5796944/b3abe484-9fe3-11e4-8409-3995b9ceae63.png)
