### PR TITLE
REDSHOP-928 update mexican peso ISO on old install

### DIFF
--- a/component/admin/sql/updates/mysql/1.5.sql
+++ b/component/admin/sql/updates/mysql/1.5.sql
@@ -1,3 +1,6 @@
 ALTER TABLE `#__redshop_product_download` CHANGE `download_id` `download_id` VARCHAR(255)
 CHARACTER SET utf8
 COLLATE utf8_general_ci NOT NULL DEFAULT '';
+
+REPLACE INTO `#__redshop_currency` VALUES
+	(99, 'Mexican Peso', 'MXN');

--- a/component/admin/sql/updates/mysql/1.x.sql
+++ b/component/admin/sql/updates/mysql/1.x.sql
@@ -1,2 +1,0 @@
-REPLACE INTO `#__redshop_currency` VALUES
-	(99, 'Mexican Peso', 'MXN');


### PR DESCRIPTION
I just noticed that we created 1.x.sql to add all the database updates and rename it when we will now the release name but we forgot about that file. I'm removing 1.x.sql and placing the table update at the 1.5.sql.

The mexican peso is only for old installs, it was already fixed in 1.3.3.1 installation.
