### PR TITLE
REDSHOP-1979 #comment Reorder folder names, delete duplicate name folder

### DIFF
--- a/libraries/redshop/redshop.xml
+++ b/libraries/redshop/redshop.xml
@@ -17,15 +17,14 @@
 	<files>
 		<folder>config</folder>
 		<folder>controller</folder>
-		<folder>html</folder>
 		<folder>form</folder>
 		<folder>helper</folder>
+		<folder>html</folder>
 		<folder>layout</folder>
 		<folder>layouts</folder>
 		<folder>model</folder>
 		<folder>toolbar</folder>
 		<folder>view</folder>
-		<folder>helper</folder>
 		<filename>index.html</filename>
 		<filename>library.php</filename>
 		<filename>redshop.xml</filename>


### PR DESCRIPTION
PR not fixed bug, because joomla 3.4.0b1 have self bug in installation script
