### PR TITLE
REDSHOP-1986 Show name at custom fields instead of value

### DIFF
--- a/component/admin/helpers/extra_field.php
+++ b/component/admin/helpers/extra_field.php
@@ -193,7 +193,7 @@ class extra_field
 					for ($c = 0; $c < count($field_chk); $c++)
 					{
 						$selected = ($field_chk[$c]->field_value == $data_value->data_txt) ? ' selected="selected" ' : '';
-						$extra_field_value .= '<option value="' . $field_chk[$c]->field_value . '" ' . $selected . ' ' . $required . $reqlbl . $errormsg . '>' . $field_chk[$c]->field_value . '</option>';
+						$extra_field_value .= '<option value="' . $field_chk[$c]->field_value . '" ' . $selected . ' ' . $required . $reqlbl . $errormsg . '>' . $field_chk[$c]->field_name . '</option>';
 					}
 
 					$extra_field_value .= '</select>';
@@ -211,7 +211,7 @@ class extra_field
 					for ($c = 0; $c < count($field_chk); $c++)
 					{
 						$selected = (@in_array(urlencode($field_chk[$c]->field_value), $chk_data)) ? ' selected="selected" ' : '';
-						$extra_field_value .= '<option value="' . urlencode($field_chk[$c]->field_value) . '" ' . $selected . ' ' . $required . $reqlbl . $errormsg . '>' . $field_chk[$c]->field_value . '</option>';
+						$extra_field_value .= '<option value="' . urlencode($field_chk[$c]->field_value) . '" ' . $selected . ' ' . $required . $reqlbl . $errormsg . '>' . $field_chk[$c]->field_name . '</option>';
 					}
 
 					$extra_field_value .= '</select>';


### PR DESCRIPTION
we using "select box" on another page and we see this. :)
- in administrator go to custom fields
- click on "new"
- Type "Single select"
- Section: Product
- Display in Product List:  No
- Show in Checkout:  No
- Show in Front: Yes
- Required: No
- Published: Yes
- scroll down to Options
- Add some options Name and values

![se](https://cloud.githubusercontent.com/assets/7931918/5963789/7101f948-a7ef-11e4-8864-1dfbc871efd2.png)
(in my cases)
- save it
- In administrator  go to product and click on one off them.
- click on "Custom Fields"
- in select box now will show options names.
  ![se2](https://cloud.githubusercontent.com/assets/7931918/5964059/6f47a420-a7f1-11e4-9eb0-0eb4ccbc0938.png)

(in my cases)
