### PR TITLE
REDSHOP-1987 Fixed VAT sent to payer API

### DIFF
--- a/plugins/redshop_payment/rs_payment_payer/rs_payment_payer.xml
+++ b/plugins/redshop_payment/rs_payment_payer/rs_payment_payer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="2.5.0" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_PAYER</name>
-    <version>1.3.3</version>
+    <version>1.5</version>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_payer/rs_payment_payer/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_payer/rs_payment_payer/extra_info.php
@@ -35,6 +35,13 @@ else
 // Loads Payers API.
 include JPATH_SITE . '/plugins/redshop_payment/' . $plugin . '/' . $plugin . '/payread_post_api.php';
 
+// Session variable
+$session = JFactory::getSession();
+$vatRate = $session->get('rs_user')['taxData']->tax_rate;
+
+// Convert rate into percentage
+$vatRate *= 100;
+
 // Creates an object from Payers API.
 $thePayreadApi = new payread_post_api;
 $thePayreadApi->add_valid_ip($_SERVER["REMOTE_ADDR"]);
@@ -68,13 +75,11 @@ for ($i = 0; $i < count($orderItemDetails); $i++)
 	$product_item_price = $currencyClass->convert($orderItemDetails[$i]->product_item_price, '', $currency_main);
 	$product_item_price_excl_vat = $currencyClass->convert($orderItemDetails[$i]->product_item_price_excl_vat, '', $currency_main);
 
-	$vat = $product_item_price - $product_item_price_excl_vat;
-	$vat = $currencyClass->convert($vat, '', $currency_main);
 	$thePayreadApi->add_freeform_purchase(
 		$i + 1,
 		$orderItemDetails[$i]->order_item_name,
 		$product_item_price,
-		$vat,
+		$vatRate,
 		$orderItemDetails[$i]->product_quantity
 	);
 }
@@ -82,13 +87,6 @@ for ($i = 0; $i < count($orderItemDetails); $i++)
 if ($order->order_shipping > 0)
 {
 	$i++;
-	$order_shipping_tax = 0;
-
-	if ($order->order_shipping_tax > 0 && $order->order_shipping_tax != null)
-	{
-		$order_shipping_tax = $order->order_shipping_tax;
-		$order_shipping_tax = $currencyClass->convert($order_shipping_tax, '', $currency_main);
-	}
 
 	$order_shipping = $currencyClass->convert($order->order_shipping, '', $currency_main);
 
@@ -96,7 +94,7 @@ if ($order->order_shipping > 0)
 		$i + 1,
 		"Order Shipping",
 		$order_shipping,
-		$order_shipping_tax,
+		$vatRate,
 		1
 	);
 }

--- a/plugins/redshop_payment/rs_payment_payer/rs_payment_payer/payread_post_api.php
+++ b/plugins/redshop_payment/rs_payment_payer/rs_payment_payer/payread_post_api.php
@@ -424,7 +424,7 @@ class payread_post_api
 	 * @param string $theLineNumber  order of the output lines of the products buyed, starting at 1. (required)
 	 * @param string $theDescription decription of the product buyed. (required)
 	 * @param int    $thePrice       price of the product buyed. (required)
-	 * @param int    $theVat         vat of the product buyed. (required)
+	 * @param int    $theVat         vat percentage of the product buyed. (required)
 	 * @param int    $theQuantity    quantity of the product buyed. (required)
 	 *
 	 * @return  nothing


### PR DESCRIPTION
The payer API expects a percentage as the VAT value, not the actual value of the VAT for that product. Yes, this does mean that payer.se calculates the actual value on their end, which means that some discounts applied "after VAT" will not be working properly with payer.se.

Couldn't find an option to change that behaviour.
