### PR TITLE
REDSHOP-1960

### DIFF
--- a/component/site/views/search/view.html.php
+++ b/component/site/views/search/view.html.php
@@ -279,6 +279,7 @@ class RedshopViewSearch extends RedshopView
 			$template_org = str_replace("{filter_by}", '', $template_org);
 			$template_org = str_replace("{template_selector_category_lbl}", '', $template_org);
 			$template_org = str_replace("{template_selector_category}", '', $template_org);
+			$template_org = str_replace("{category_main_name}", $cat_name, $template_org);
 			$template_org = str_replace("{category_main_description}", '', $template_org);
 			$template_org = str_replace("{category_description}", '', $template_org);
 			$template_org = str_replace("{category_short_desc}", '', $template_org);
@@ -458,21 +459,21 @@ class RedshopViewSearch extends RedshopView
 				$data_add = str_replace("{product_number}", $product_number, $data_add);
 
 				// Product category tags
-				if (strstr($data_add, "{category_main_name}") || strstr($data_add, "{returntocategory_name}"))
+				$data_add = str_replace("{returntocategory_name}", $this->search[$i]->category_name, $data_add);
+
+				if (strstr($data_add, "{returntoparent_category_name}"))
 				{
 					$parentCategoryId = $producthelper->getParentCategory($this->search[$i]->category_id);
 
 					if ($parentCategoryId != 0)
 					{
 						$parentCategory = $producthelper->getSection("category", $parentCategoryId);
-						$data_add = str_replace("{returntocategory_name}", $parentCategory->category_name, $data_add);
+						$data_add = str_replace("{returntoparent_category_name}", $parentCategory->category_name, $data_add);
 					}
 					else
 					{
-						$data_add = str_replace("{returntocategory_name}", '', $data_add);
+						$data_add = str_replace("{returntoparent_category_name}", '', $data_add);
 					}
-
-					$data_add = str_replace("{category_main_name}", $this->search[$i]->category_name, $data_add);
 				}
 
 				/**

--- a/component/site/views/search/view.html.php
+++ b/component/site/views/search/view.html.php
@@ -460,9 +460,7 @@ class RedshopViewSearch extends RedshopView
 				// Product category tags
 				if (strstr($data_add, "{category_main_name}") || strstr($data_add, "{returntocategory_name}"))
 				{
-					$currentCategoryId = $producthelper->getCategoryProduct($this->search[$i]->product_id);
-					$currentCategory = $producthelper->getCategoryNameByProductId($this->search[$i]->product_id);
-					$parentCategoryId = $producthelper->getParentCategory($currentCategoryId);
+					$parentCategoryId = $producthelper->getParentCategory($this->search[$i]->category_id);
 
 					if ($parentCategoryId != 0)
 					{
@@ -474,7 +472,7 @@ class RedshopViewSearch extends RedshopView
 						$data_add = str_replace("{returntocategory_name}", '', $data_add);
 					}
 
-					$data_add = str_replace("{category_main_name}", $currentCategory, $data_add);
+					$data_add = str_replace("{category_main_name}", $this->search[$i]->category_name, $data_add);
 				}
 
 				/**


### PR DESCRIPTION
Changes as per @shandak's comments in my last PR.

Now tags are definitely fixed and inline with the standard.

`{category_main_name}`: the name passed as an argument to the search
`{returntocategory_name}`: the name of the category the product belongs to
`{returntoparent_category_name}`: the name of the parent category
