### PR TITLE
Prepare for the next release

### DIFF
--- a/redshop.xml
+++ b/redshop.xml
@@ -7,7 +7,7 @@
     <authorUrl>www.redweb.dk</authorUrl>
     <copyright>(c) Redweb.dk</copyright>
     <license>GNU/GPL</license>
-    <version>1.5</version>
+    <version>1.5.0.1</version>
     <description>COM_REDSHOP_DESCRIPTION</description>
     <scriptfile>install.php</scriptfile>
     <install>


### PR DESCRIPTION
@shandak @gunjanpatel sounds good if we update the current version to 1.5.0.1. Now that we have released 1.5 I think is good that we can do small hotfix releases with the bugs that will be discovered during the week.

so I thought that 1.5.0.1, 1.5.0.2, ... sounds better than release 1.5.1 (specially if we do it in less than a month from today)

Any one against?

![screen shot 2015-02-03 at 17 26 48](https://cloud.githubusercontent.com/assets/1375475/6024139/4da0aec6-abc9-11e4-9565-91355ec56315.png)
