### PR TITLE
REDSHOP-2013 add core compatibility tag on plugins

### DIFF
--- a/plugins/system/redlightbox_slideshow/redlightbox_slideshow.xml
+++ b/plugins/system/redlightbox_slideshow/redlightbox_slideshow.xml
@@ -3,6 +3,7 @@
     <name>System - Redlightbox Slideshow</name>
     <author>redCOMPONENT.com</author>
     <version>2.0.2</version>
+    <redshop>1.5</redshop>
     <creationDate>June 2013</creationDate>
     <copyright>redCOMPONENT.com</copyright>
     <license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>

--- a/plugins_packager.xml
+++ b/plugins_packager.xml
@@ -58,7 +58,7 @@
     <!-- ============================================  -->
     <!-- Target: build                                 -->
     <!-- ============================================  -->
-    <!-- Loops through folders creating module packages -->
+    <!-- Loops through folders creating plugins packages -->
 
     <target name="build" depends="prepare">
 		<!-- Loop through plugins groups -->
@@ -101,9 +101,30 @@
                 name="plugin_version"
                 value="${pluginmanifest.version}"
                 override="true"/>
+        <!-- Todo: the following code checks compatibility with redSHOP Core version. The code works, but it can be improved with some PHING knowledge -->
+        <property
+                name="redshop_compatibility"
+                value="${pluginmanifest.redshop}"
+                override="true"/>
+
+        <if>
+            <contains string="${redshop_compatibility}" substring="pluginmanifest.redshop" />
+            <then>
+                <property
+                        name="redshop_compatibility"
+                        value=""
+                        override="true"/>
+            </then>
+            <else>
+                <property
+                        name="redshop_compatibility"
+                        value="_for_redSHOP${redshop_compatibility}"
+                        override="true"/>
+            </else>
+        </if>
 
         <zip
-				destfile="${tmpdir}/${group_name}/${group_name}_${plugin_name}_${plugin_version}.zip"
+				destfile="${tmpdir}/${group_name}/${group_name}_${plugin_name}_${plugin_version}${redshop_compatibility}.zip"
 				basedir="${extpath}/plugins/${group_name}/${plugin_name}">
 			<fileset dir="${extpath}/plugins/${group_name}/${plugin_name}">
 				<include name="**" />

--- a/redshop.xml
+++ b/redshop.xml
@@ -7,7 +7,7 @@
     <authorUrl>www.redweb.dk</authorUrl>
     <copyright>(c) Redweb.dk</copyright>
     <license>GNU/GPL</license>
-    <version>1.5</version>
+    <version>1.5.0.1</version>
     <description>COM_REDSHOP_DESCRIPTION</description>
     <scriptfile>install.php</scriptfile>
     <install>


### PR DESCRIPTION
This modification will allow us to have this:

![screen shot 2015-02-04 at 10 40 00](https://cloud.githubusercontent.com/assets/1375475/6038072/273d0c7a-ac5a-11e4-97ae-fd59ad8665c2.png)
