### PR TITLE
REDSHOP-1992 update module ver redSHOP 1.5 ready

### DIFF
--- a/modules/site/mod_redproducts3d/mod_redproducts3d.xml
+++ b/modules/site/mod_redproducts3d/mod_redproducts3d.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="module" version="1.6.0" client="site" method="upgrade">
     <name>MOD_REDPRODUCTS3D</name>
-    <version>1.3.2</version>
+    <version>1.5</version>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>


### PR DESCRIPTION
The plugin works in joomla 2 and joomla 3 after the fix at #1555. 

Well it does not respect the limits when the module is in a narrow space, but I think it has sense that this module is only used in horizontal spaces:
![screen shot 2015-02-05 at 13 47 30](https://cloud.githubusercontent.com/assets/1375475/6060471/a80d372e-ad3d-11e4-892d-a521f9684ae3.png)

so updating the version to make @ot2sen know that this module is good to be added to the list of redSHOP 1.5 compatible extensions
