### PR TITLE
REDSHOP-2038 update 1.5 compatible payment plugins

### DIFF
--- a/plugins/redshop_payment/rs_payment_authorize/rs_payment_authorize.xml
+++ b/plugins/redshop_payment/rs_payment_authorize/rs_payment_authorize.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_AUTHORIZE</name>
     <version>1.3.2</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_bbs/rs_payment_bbs.xml
+++ b/plugins/redshop_payment/rs_payment_bbs/rs_payment_bbs.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_BBS</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_beanstream/rs_payment_beanstream.xml
+++ b/plugins/redshop_payment/rs_payment_beanstream/rs_payment_beanstream.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_BEANSTREAM</name>
     <version>1.2</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_braintree/rs_payment_braintree.xml
+++ b/plugins/redshop_payment/rs_payment_braintree/rs_payment_braintree.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_BRAINTREE</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.xml
+++ b/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_EPAYV2</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_eway/rs_payment_eway.xml
+++ b/plugins/redshop_payment/rs_payment_eway/rs_payment_eway.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_EWAY</name>
     <version>1.3.2</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_mollieideal/rs_payment_mollieideal.xml
+++ b/plugins/redshop_payment/rs_payment_mollieideal/rs_payment_mollieideal.xml
@@ -3,6 +3,7 @@
            method="upgrade">
     <name>PLG_RS_PAYMENT_MOLLIEIDEAL</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_moneris/rs_payment_moneris.xml
+++ b/plugins/redshop_payment/rs_payment_moneris/rs_payment_moneris.xml
@@ -3,6 +3,7 @@
            method="upgrade">
     <name>PLG_RS_PAYMENT_MONERIS</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_moneybooker/rs_payment_moneybooker.xml
+++ b/plugins/redshop_payment/rs_payment_moneybooker/rs_payment_moneybooker.xml
@@ -3,6 +3,7 @@
            method="upgrade">
     <name>PLG_RS_PAYMENT_MONEYBOOKER</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_payflowpro/rs_payment_payflowpro.xml
+++ b/plugins/redshop_payment/rs_payment_payflowpro/rs_payment_payflowpro.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
   <name>PLG_RS_PAYMENT_PAYFLOWPRO</name>
   <version>1.5</version>
+  <redshop>1.5</redshop>
   <creationDate>April 2013</creationDate>
   <author>redCOMPONENT.com</author>
   <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_payment_express/rs_payment_payment_express.xml
+++ b/plugins/redshop_payment/rs_payment_payment_express/rs_payment_payment_express.xml
@@ -3,6 +3,7 @@
            method="upgrade">
     <name>PLG_RS_PAYMENT_PAYMENT_EXPRESS</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_paypalpro/rs_payment_paypalpro.xml
+++ b/plugins/redshop_payment/rs_payment_paypalpro/rs_payment_paypalpro.xml
@@ -3,6 +3,7 @@
            method="upgrade">
     <name>PLG_RS_PAYMENT_PAYPALPRO</name>
     <version>1.3.2</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_payson/rs_payment_payson.xml
+++ b/plugins/redshop_payment/rs_payment_payson/rs_payment_payson.xml
@@ -3,6 +3,7 @@
            method="upgrade">
     <name>PLG_RS_PAYMENT_PAYSON</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_quickpay/rs_payment_quickpay.xml
+++ b/plugins/redshop_payment/rs_payment_quickpay/rs_payment_quickpay.xml
@@ -2,6 +2,7 @@
 <extension version="2.5" type="plugin" group="redshop_payment" method="upgrade" client="site">
     <name>PLG_RS_PAYMENT_QUICKPAY</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>

--- a/plugins/redshop_payment/rs_payment_sagepay/rs_payment_sagepay.xml
+++ b/plugins/redshop_payment/rs_payment_sagepay/rs_payment_sagepay.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_SAGEPAY</name>
     <version>1.3.3</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>


### PR DESCRIPTION
# Do not merge: work in progress

This pull updates the plugins that have been tested and work with redSHOP 1.5 while setting them ready for release.

Do not merge, we are awaiting for some test from Oscar.
