### PR TITLE
REDSHOP-2073 add j2.5 and j3 comatibility in zip

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -9,7 +9,7 @@ comp.name=redshop
 package.dir=
 
 # Joomla version to include in the package name, when using packager xml files
-joomla.version=3
+joomla.version=j3_and_j25
 
 # Testing Joomla site at a localhost folder. Only needed when using build.xml
 www.dir=

--- a/component_packager.xml
+++ b/component_packager.xml
@@ -131,28 +131,28 @@
 
         <!-- Extension ZIP packaging -->
         <if>
-            <available file="${package.dir}/${extension}-v${version}_j${joomla.version}.zip" property="test_zip_exists" value="Yes"/>
+            <available file="${package.dir}/${extension}-v${version}_${joomla.version}.zip" property="test_zip_exists" value="Yes"/>
             <then>
                 <echo msg="Removing old ZIP"/>
-                <delete file="${package.dir}/${extension}-v${version}_j${joomla.version}.zip" />
+                <delete file="${package.dir}/${extension}-v${version}_${joomla.version}.zip" />
             </then>
         </if>
 
         <if>
-            <available file="${tmpdir}/${extension}-v${version}_j${joomla.version}.zip" property="test_zip_exists" value="Yes"/>
+            <available file="${tmpdir}/${extension}-v${version}_${joomla.version}.zip" property="test_zip_exists" value="Yes"/>
             <then>
-                <delete file="${tmpdir}/${extension}-v${version}_j${joomla.version}.zip" />
+                <delete file="${tmpdir}/${extension}-v${version}_${joomla.version}.zip" />
             </then>
         </if>
 
-        <zip destfile="${tmpdir}/${extension}-v${version}_j${joomla.version}.zip">
+        <zip destfile="${tmpdir}/${extension}-v${version}_${joomla.version}.zip">
             <fileset dir="${tmpdir}/${extension}">
                 <include name="**"/>
                 <exclude name=".*"/>
             </fileset>
         </zip>
 
-        <copy file="${tmpdir}/${extension}-v${version}_j${joomla.version}.zip" tofile="${package.dir}/${extension}-v${version}_j${joomla.version}.zip" />
+        <copy file="${tmpdir}/${extension}-v${version}_${joomla.version}.zip" tofile="${package.dir}/${extension}-v${version}_${joomla.version}.zip" />
 
         <echo msg="Files copied and compressed in build directory OK!"/>
     </target>
@@ -203,7 +203,7 @@
 
         <property
                 name="joomla.version"
-                value="3"
+                value="j3_j25"
                 override="true"/>
 
         <property


### PR DESCRIPTION
This pull shows that redSHOP core is compatible with Joomla 2.5 and Joomla 3 to avoid confusion when clients download the file.

Remember to update your build.properties

The new package will get the name: redshop-v1.5.0.1_j3_and_j25.zip

Please @ot2sen confirm that it works for you.
