### PR TITLE
REDSHOP-2002 update module version for release

### DIFF
--- a/modules/site/mod_redshop_who_bought/mod_redshop_who_bought.xml
+++ b/modules/site/mod_redshop_who_bought/mod_redshop_who_bought.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="module" version="1.6.0" client="site" method="upgrade">
     <name>MOD_REDSHOP_WHO_BOUGHT</name>
-    <version>1.5</version>
+    <version>1.5.1</version>
     <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>


### PR DESCRIPTION
This pull updates #1632 because fixes were added in the Who Bought module, so we need to bump version to do a second release of the module.
