### PR TITLE
REDSHOP-2134 Update postdanmark shipping plugin - using unique shop locations

### DIFF
--- a/plugins/redshop_shipping/postdanmark/language/en-GB/en-GB.plg_redshop_shipping_postdanmark.ini
+++ b/plugins/redshop_shipping/postdanmark/language/en-GB/en-GB.plg_redshop_shipping_postdanmark.ini
@@ -7,7 +7,7 @@
 ; license GNU/GPL, see LICENSE.php
 
 PLG_REDSHOP_SHIPPING_POSTDANMARK="PostDanmark - Shipping Location"
-PLG_REDSHOP_SHIPPING_POSTDANMARK_DESC="Get PostDanmark Shipping Location Information based on zipcode. <br /><br /><h1 class="_QQ_"red"_QQ_">Please install &quot;redSHOP PostDanmark redshop_product type plugin &quot; too before continue. Ignore if already installed.</h1>"
+PLG_REDSHOP_SHIPPING_POSTDANMARK_DESC="Get PostDanmark Shipping Location Information based on zipcode. <br /><br /><h1 class="_QQ_"red"_QQ_">Please install &quot;redSHOP PostDanmark redshop_product type plugin &quot; too before continue. Ignore if already installed.</h1>API Url: http://logistics.postennorden.com/wsp/docs/servicepoints/findNearestByAddress.html <br /> API Explorer: http://logistics.postennorden.com/wsp/docs/explore.html?resource=servicepoints/findNearestByAddress"
 
 PLG_REDSHOP_SHIPPING_POSTDANMARK_CONSUMERID="PostDanmark Consumer Id"
-PLG_REDSHOP_SHIPPING_POSTDANMARK_CONSUMERID_DESC="Please enter your valid postdanmark consumer id."
+PLG_REDSHOP_SHIPPING_POSTDANMARK_CONSUMERID_DESC="The unique consumer (client) identifier. UUID. 36 characters. Example: 550e9400-e29b-61d4-a716-446655440000."

--- a/plugins/redshop_shipping/postdanmark/postdanmark.php
+++ b/plugins/redshop_shipping/postdanmark/postdanmark.php
@@ -220,10 +220,19 @@ class Plgredshop_ShippingPostdanmark extends JPlugin
 			}
 			else
 			{
-				$cnt     = 0;
-				$count   = count($shops);
+				// Unique shop locations based on their servicePointId
+				$uniqueShops = array();
 
-				foreach ($shops as $key => $shop)
+				// Loop through shops to make it unique
+				foreach ($shops as $shop)
+				{
+					$uniqueShops[$shop->servicePointId] = $shop;
+				}
+
+				$cnt     = 0;
+				$count   = count($uniqueShops);
+
+				foreach ($uniqueShops as $shop)
 				{
 					$response .= $this->createShop($shop, $cnt, $count);
 					$cnt++;


### PR DESCRIPTION
Post denmark shipping gateways gives api to get shop locations. We already have build plugin for it.
Install, 
1. redshop_product/postdenmark
2. redshop_shipping/postdenmark 
plugins.
- Add shipping rate in postdenmark shipping gateway.
- Add consumer id in postdenmark shipping gateway (don't know if we have testing consumer id but you may try to ask Hans)
- Proceed to check out and select shipping rate
- You will get button to get shops based on your postcode (use any Denmark postcode).
- make sure they are unique (actual fix of this PR)
