### PR TITLE
REDSHOP-2166 XTREM-91 Add category id in related product link

### DIFF
--- a/component/site/helpers/product.php
+++ b/component/site/helpers/product.php
@@ -10255,7 +10255,7 @@ class producthelper
 					}
 
 					$rlink = JRoute::_('index.php?option=com_redshop&view=product&pid='
-						. $related_product[$r]->product_id . '&Itemid=' . $pItemid);
+								. $related_product[$r]->product_id . '&cid=' . $related_product[$r]->cat_in_sefurl . '&Itemid=' . $pItemid);
 
 					if (strstr($related_template_data, "{relproduct_image_3}"))
 					{
@@ -10340,13 +10340,10 @@ class producthelper
 						}
 					}
 
-					$relmorelink           = JRoute::_('index.php?option=com_redshop&view=product&pid='
-						. $related_product [$r]->product_id . '&cid=' . $related_product[$r]->cat_in_sefurl . '&Itemid='
-						. $pItemid);
-					$rmore                 = "<a href='" . $relmorelink . "' title='" . $related_product [$r]->product_name
+					$rmore                 = "<a href='" . $rlink . "' title='" . $related_product [$r]->product_name
 						. "'>" . JText::_('COM_REDSHOP_READ_MORE') . "</a>";
 					$related_template_data = str_replace("{read_more}", $rmore, $related_template_data);
-					$related_template_data = str_replace("{read_more_link}", $relmorelink, $related_template_data);
+					$related_template_data = str_replace("{read_more_link}", $rlink, $related_template_data);
 					/*
 					 *  related product Required Attribute start
 					 * 	this will parse only Required Attributes

--- a/component/site/helpers/product.php
+++ b/component/site/helpers/product.php
@@ -10210,8 +10210,16 @@ class producthelper
 		return $templatedata;
 	}
 
-// function for related product layout
-
+	/**
+	 * Parse related product template
+	 *
+	 * @param   string   $template_desc  Template Contents
+	 * @param   integer  $product_id     Product Id
+	 *
+	 * @todo    Move this functionality to library helper and convert this code into JLayout
+	 *
+	 * @return  string   Parsed Template HTML
+	 */
 	public function getRelatedtemplateView($template_desc, $product_id)
 	{
 		$extra_field      = new extraField;
@@ -10254,8 +10262,7 @@ class producthelper
 						$pItemid = $redhelper->getItemid($related_product[$r]->product_id);
 					}
 
-					$rlink = JRoute::_('index.php?option=com_redshop&view=product&pid='
-								. $related_product[$r]->product_id . '&cid=' . $related_product[$r]->cat_in_sefurl . '&Itemid=' . $pItemid);
+					$rlink = JRoute::_('index.php?option=com_redshop&view=product&pid=' . $related_product[$r]->product_id . '&cid=' . $related_product[$r]->cat_in_sefurl . '&Itemid=' . $pItemid);
 
 					if (strstr($related_template_data, "{relproduct_image_3}"))
 					{
@@ -10320,7 +10327,6 @@ class producthelper
 
 					// ProductFinderDatepicker Extra Field Start
 					$related_template_data = $this->getProductFinderDatepickerValue($related_template_data, $related_product[$r]->product_id, $fieldArray);
-					// ProductFinderDatepicker Extra Field End
 
 					if (strstr($related_template_data, "{manufacturer_name}") || strstr($related_template_data, "{manufacturer_link}"))
 					{
@@ -10340,15 +10346,16 @@ class producthelper
 						}
 					}
 
-					$rmore                 = "<a href='" . $rlink . "' title='" . $related_product [$r]->product_name
-						. "'>" . JText::_('COM_REDSHOP_READ_MORE') . "</a>";
+					$rmore = '<a href="' . $rlink . '" title="' . $related_product [$r]->product_name . '">'
+								. JText::_('COM_REDSHOP_READ_MORE')
+							. '</a>';
 					$related_template_data = str_replace("{read_more}", $rmore, $related_template_data);
 					$related_template_data = str_replace("{read_more_link}", $rlink, $related_template_data);
+
 					/*
 					 *  related product Required Attribute start
 					 * 	this will parse only Required Attributes
 					 */
-
 					$relid          = $related_product [$r]->product_id;
 					$attributes_set = array();
 
@@ -10372,7 +10379,7 @@ class producthelper
 					$related_template_data = $this->getProductOnSaleComment($related_product[$r], $related_template_data);
 					$related_template_data = $this->getSpecialProductComment($related_product[$r], $related_template_data);
 
-					// related product attribute price list
+					// Related product attribute price list
 					$related_template_data = $this->replaceAttributePriceList($related_product[$r]->product_id, $related_template_data);
 				}
 

--- a/plugins/search/redshop_products/redshop_products.php
+++ b/plugins/search/redshop_products/redshop_products.php
@@ -90,7 +90,8 @@ class plgSearchRedshop_products extends JPlugin
 						$db->qn('product_s_desc', 'text'),
 						'"' . $section . '" AS ' . $db->qn('section'),
 						'"" AS ' . $db->qn('created'),
-						'"2" AS ' . $db->qn('browsernav')
+						'"2" AS ' . $db->qn('browsernav'),
+						$db->qn('cat_in_sefurl')
 					)
 				)
 				->from($db->qn('#__redshop_product'));
@@ -202,7 +203,7 @@ class plgSearchRedshop_products extends JPlugin
 		foreach ($rows as $key => $row)
 		{
 			$Itemid    = $redhelper->getItemid($row->product_id);
-			$row->href = "index.php?option=com_redshop&view=product&pid=" . $row->product_id . "&Itemid=" . $Itemid;
+			$row->href = "index.php?option=com_redshop&view=product&pid=" . $row->product_id . "&cid=" . $row->cat_in_sefurl . "&Itemid=" . $Itemid;
 
 			$return[]  = $row;
 		}


### PR DESCRIPTION
- Go to product detail page in frontend which have related 
- Check related products Image and Name urls 
- Before patch you will find that there is not category id `cid=xxx` added in url of image. (If you see image path in url then go to configuration and  set `Show Product Images in Lightbox` => `No` in General tab.)
- Make sure that both the urls are same after applying this patch.
