### PR TITLE
REDSHOP-2172 add Flemish language

### DIFF
--- a/plugins/redshop_payment/rs_payment_ogone/rs_payment_ogone.xml
+++ b/plugins/redshop_payment/rs_payment_ogone/rs_payment_ogone.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_OGONE</name>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>
@@ -77,7 +77,7 @@
                 <field name="language" type="list" default="0" label="Ogone Language" description="Ogone Language">
                     <option value="da_DK">Danish</option>
                     <option value="nl_NL">Dutch</option>
-                    <option value="nl_BE">Dutch (Belgi?)</option>
+                    <option value="nl_BE">Flemish</option>
                     <option value="en_GB">English (UK)</option>
                     <option value="en_US">English (US)</option>
                     <option value="fr_CA">French (Canada)</option>


### PR DESCRIPTION
just a small hotfix:

![screen shot 2015-03-11 at 11 07 39](https://cloud.githubusercontent.com/assets/1375475/6594077/35419b34-c7de-11e4-974b-7299b0575036.png)

Before there was a wrong text saying Belgi? instead of Flemish, witch is the right name of the language.
