### PR TITLE
REDSHOP-2224 Fix MD5 check in Epay plugin in sending group

### DIFF
--- a/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
+++ b/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
@@ -61,7 +61,6 @@ class PlgRedshop_Paymentrs_Payment_Epayv2 extends JPlugin
 			'amount'          => number_format($data['carttotal'], 2, '.', '') * 100,
 			'currency'        => $CurrencyHelper->get_iso_code(CURRENCY_CODE),
 			'orderid'         => $data['order_id'],
-			'group'           => $this->params->get("payment_group"),
 			'instantcapture'  => $this->params->get("auth_type"),
 			'instantcallback' => 1,
 			'language'        => $this->params->get("language"),
@@ -70,6 +69,12 @@ class PlgRedshop_Paymentrs_Payment_Epayv2 extends JPlugin
 			'ownreceipt'      => $this->params->get("ownreceipt"),
 			'subscription'    => $this->params->get("epay_subscription")
 		);
+
+		// Payment Group is an optional
+		if ($this->params->get('payment_group'))
+		{
+			$formdata['group'] = $this->params->get('payment_group');
+		}
 
 		if ((int) $this->params->get('activate_callback', 0) == 1)
 		{


### PR DESCRIPTION
**Testing Info**
- To confirm the issue pay order with epay without setting "Group" in epayv2 plugin detail
- You will get wrong HASH key error from epay.
- Apply patch and test
