### PR TITLE
REDSHOP-2045 Remove start and enddates when removing mass discount

### DIFF
--- a/component/admin/models/mass_discount_detail.php
+++ b/component/admin/models/mass_discount_detail.php
@@ -472,11 +472,14 @@ class RedshopModelMass_discount_detail extends RedshopModel
 		if (count($productId) > 0)
 		{
 			JArrayHelper::toInteger($productId);
+
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
-				->update('#__redshop_product')
-				->set('product_on_sale = 0')
-				->where('product_id IN (' . implode(',', $productId) . ')');
+				->update($db->qn('#__redshop_product'))
+				->set($db->qn('product_on_sale') . ' = 0')
+				->set($db->qn('discount_stratdate') . ' = 0')
+				->set($db->qn('discount_enddate') . ' = 0')
+				->where($db->qn('product_id') . ' IN (' . implode(',', $productId) . ')');
 
 			if (!$db->setQuery($query)->execute())
 			{


### PR DESCRIPTION
**Testing Info**
- Add mass discount on specific product
- Go to that product detail and make sure discount is applied = Product is on sale
- Now, Remove mass discount
- Check that discount is removed from product = Product is not on sale
