### PR TITLE
REDSHOP-2050 Update paymil payment compatibility tag

### DIFF
--- a/plugins/redshop_payment/rs_payment_paymill/rs_payment_paymill.xml
+++ b/plugins/redshop_payment/rs_payment_paymill/rs_payment_paymill.xml
@@ -2,6 +2,7 @@
 <extension version="2.5.0" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_PAYMILL</name>
     <version>1.5.1</version>
+    <redshop>1.5</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>


### PR DESCRIPTION
Updates the zip package name to show compatibility with redSHOP 1.5

![screen shot 2015-03-30 at 09 43 18](https://cloud.githubusercontent.com/assets/1375475/6892058/b61f2adc-d6c0-11e4-91f1-b97992b31f75.png)
