### PR TITLE
REDSHOP-2158 Update postdanmark product plugin compatibility with redSHOP 1.5

### DIFF
--- a/plugins/redshop_product/postdanmark/postdanmark.xml
+++ b/plugins/redshop_product/postdanmark/postdanmark.xml
@@ -3,7 +3,8 @@
 	<name>PLG_REDSHOP_PRODUCT_POSTDANMARK</name>
 	<author>redCOMPONENT.com</author>
 	<version>1.0</version>
-	<creationDate>Septmber 2014</creationDate>
+    <redshop>1.5</redshop>
+	<creationDate>September 2014</creationDate>
 	<copyright>redCOMPONENT.com</copyright>
 	<license>GNU/GPL</license>
 	<authorEmail>email@redcomponent.com</authorEmail>


### PR DESCRIPTION
updates redshop_product postdanmark compatibility tag:

![screen shot 2015-03-30 at 10 07 53](https://cloud.githubusercontent.com/assets/1375475/6892406/f9a2178a-d6c3-11e4-92dd-4761ab9103dd.png)
