### PR TITLE
REDSHOP-2265 # Ajax search return the wrong result

### DIFF
--- a/component/site/models/search.php
+++ b/component/site/models/search.php
@@ -1105,7 +1105,7 @@ class RedshopModelSearch extends RedshopModel
 		$module      = JModuleHelper::getModule('redshop_search');
 		$params      = new JRegistry($module->params);
 		$limit       = $params->get('noofsearchresults');
-		$keyword     = JRequest::getCmd('input');
+		$keyword     = JRequest::getString('keyword');
 		$search_type = JRequest::getCmd('search_type');
 		$db = JFactory::getDbo();
 


### PR DESCRIPTION
How to test:

-Create a module with ajax featured.
-Seach any word.
-The result is always all products because the keywork didn't be correct.
