### PR TITLE
XTREM-96  Speed Optimisation with shopper group filtered category

### DIFF
--- a/component/site/views/category/tmpl/default.php
+++ b/component/site/views/category/tmpl/default.php
@@ -140,8 +140,7 @@ if (strstr($template_desc, "{category_frontpage_loop_start}") && strstr($templat
 			$portal = $sgportal->shopper_group_portal;
 		}
 
-		if ((PORTAL_SHOP == 1 && $checkcid == "")
-			|| ($portal == 1 && $checkcid == ""))
+		if ('' == $checkcid && (PORTAL_SHOP == 1 || $portal == 1))
 		{
 			continue;
 		}

--- a/component/site/views/category/tmpl/default.php
+++ b/component/site/views/category/tmpl/default.php
@@ -126,11 +126,30 @@ if (strstr($template_desc, "{category_frontpage_loop_start}") && strstr($templat
 	$extraFieldName = $extraField->getSectionFieldNameArray(2, 1, 1);
 	$cat_detail     = "";
 
-	for ($i = 0; $i < count($this->detail); $i++)
+	for ($i = 0, $nc = count($this->detail); $i < $nc; $i++)
 	{
 		$row = $this->detail[$i];
 
+		// Filter categories based on Shopper group category ACL
+		$checkcid = $objhelper->getShopperGroupCategory($row->category_id);
+		$sgportal = $objhelper->getShopperGroupPortal();
+		$portal   = 0;
+
+		if (count($sgportal) > 0)
+		{
+			$portal = $sgportal->shopper_group_portal;
+		}
+
+		if ((PORTAL_SHOP == 1 && $checkcid == "")
+			|| ($portal == 1 && $checkcid == ""))
+		{
+			continue;
+		}
+
 		$data_add = $middletemplate_desc;
+
+		$read_more = "<a href='" . $link . "'>" . JText::_('COM_REDSHOP_READ_MORE') . "</a>";
+		$data_add  = str_replace("{read_more}", $read_more, $data_add);
 
 		$cItemid = $objhelper->getCategoryItemid($row->category_id);
 
@@ -212,37 +231,7 @@ if (strstr($template_desc, "{category_frontpage_loop_start}") && strstr($templat
 		 */
 		$data_add = $producthelper->getExtraSectionTag($extraFieldName, $row->category_id, "2", $data_add);
 
-		// Shopper group category ACL
-		$checkcid = $objhelper->getShopperGroupCategory($row->category_id);
-
-		$read_more = "<a href='" . $link . "'>" . JText::_('COM_REDSHOP_READ_MORE') . "</a>";
-		$data_add  = str_replace("{read_more}", $read_more, $data_add);
-		$sgportal  = $objhelper->getShopperGroupPortal();
-		$portal    = 0;
-
-		if (count($sgportal) > 0)
-		{
-			$portal = $sgportal->shopper_group_portal;
-		}
-
-		if (PORTAL_SHOP == 1)
-		{
-			if ($checkcid != "")
-			{
-				$cat_detail .= $data_add;
-			}
-		}
-		else
-		{
-			if ($portal == 1 && $checkcid != "")
-			{
-				$cat_detail .= $data_add;
-			}
-			elseif ($portal == 0)
-			{
-				$cat_detail .= $data_add;
-			}
-		}
+		$cat_detail .= $data_add;
 	}
 
 	$template_desc = str_replace("{category_frontpage_loop_start}", "", $template_desc);

--- a/component/site/views/category/tmpl/default.php
+++ b/component/site/views/category/tmpl/default.php
@@ -147,9 +147,6 @@ if (strstr($template_desc, "{category_frontpage_loop_start}") && strstr($templat
 
 		$data_add = $middletemplate_desc;
 
-		$read_more = "<a href='" . $link . "'>" . JText::_('COM_REDSHOP_READ_MORE') . "</a>";
-		$data_add  = str_replace("{read_more}", $read_more, $data_add);
-
 		$cItemid = $objhelper->getCategoryItemid($row->category_id);
 
 		if ($cItemid != "")
@@ -229,6 +226,9 @@ if (strstr($template_desc, "{category_frontpage_loop_start}") && strstr($templat
 		 * "2" argument is set for category
 		 */
 		$data_add = $producthelper->getExtraSectionTag($extraFieldName, $row->category_id, "2", $data_add);
+
+		$read_more = "<a href='" . $link . "'>" . JText::_('COM_REDSHOP_READ_MORE') . "</a>";
+		$data_add  = str_replace("{read_more}", $read_more, $data_add);
 
 		$cat_detail .= $data_add;
 	}

--- a/component/site/views/category/tmpl/detail.php
+++ b/component/site/views/category/tmpl/detail.php
@@ -318,9 +318,25 @@ if (!$slide)
 
 		$cat_detail = "";
 
-		for ($i = 0; $i < count($this->detail); $i++)
+		for ($i = 0, $nc = count($this->detail); $i < $nc; $i++)
 		{
 			$row = $this->detail[$i];
+
+			// Filter categories based on Shopper group category ACL
+			$checkcid = $objhelper->getShopperGroupCategory($row->category_id);
+			$sgportal = $objhelper->getShopperGroupPortal();
+			$portal   = 0;
+
+			if (count($sgportal) > 0)
+			{
+				$portal = $sgportal->shopper_group_portal;
+			}
+
+			if ((PORTAL_SHOP == 1 && $checkcid == "")
+				|| ($portal == 1 && $checkcid == ""))
+			{
+				continue;
+			}
 
 			$data_add = $subcat_template;
 
@@ -410,34 +426,7 @@ if (!$slide)
 			 */
 			$data_add = $producthelper->getExtraSectionTag($extraFieldName, $row->category_id, "2", $data_add);
 
-			// Shopper group category ACL
-			$checkcid = $objhelper->getShopperGroupCategory($row->category_id);
-			$sgportal = $objhelper->getShopperGroupPortal();
-			$portal   = 0;
-
-			if (count($sgportal) > 0)
-			{
-				$portal = $sgportal->shopper_group_portal;
-			}
-
-			if (PORTAL_SHOP == 1)
-			{
-				if ($checkcid != "")
-				{
-					$cat_detail .= $data_add;
-				}
-			}
-			else
-			{
-				if ($portal == 1 && $checkcid != "")
-				{
-					$cat_detail .= $data_add;
-				}
-				elseif ($portal == 0)
-				{
-					$cat_detail .= $data_add;
-				}
-			}
+			$cat_detail .= $data_add;
 		}
 
 		$template_desc = str_replace("{category_loop_start}", "", $template_desc);
@@ -536,7 +525,7 @@ if (strstr($template_desc, "{product_loop_start}") && strstr($template_desc, "{p
 			$media_documents = $producthelper->getAdditionMediaImage($product->product_id, "product", "document");
 			$more_doc        = '';
 
-			for ($m = 0; $m < count($media_documents); $m++)
+			for ($m = 0, $nm = count($media_documents); $m < $nm; $m++)
 			{
 				$alttext = $producthelper->getAltText("product", $media_documents[$m]->section_id, "", $media_documents[$m]->media_id, "document");
 
@@ -573,7 +562,7 @@ if (strstr($template_desc, "{product_loop_start}") && strstr($template_desc, "{p
 		{
 			$ufield = "";
 
-			for ($ui = 0; $ui < count($userfieldArr); $ui++)
+			for ($ui = 0, $nui = count($userfieldArr); $ui < $nui; $ui++)
 			{
 				$product_userfileds = $extraField->list_all_user_fields($userfieldArr[$ui], 12, '', '', 0, $product->product_id);
 				$ufield .= $product_userfileds[1];
@@ -619,7 +608,7 @@ if (strstr($template_desc, "{product_loop_start}") && strstr($template_desc, "{p
 			{
 				$ufield = "";
 
-				for ($ui = 0; $ui < count($userfieldArr); $ui++)
+				for ($ui = 0, $nui = count($userfieldArr); $ui < $nui; $ui++)
 				{
 					$product_userfileds = $extraField->list_all_user_fields($userfieldArr[$ui], 12, '', '', 0, $product->product_id);
 					$ufield .= $product_userfileds[1];

--- a/component/site/views/category/tmpl/detail.php
+++ b/component/site/views/category/tmpl/detail.php
@@ -332,8 +332,7 @@ if (!$slide)
 				$portal = $sgportal->shopper_group_portal;
 			}
 
-			if ((PORTAL_SHOP == 1 && $checkcid == "")
-				|| ($portal == 1 && $checkcid == ""))
+			if ('' == $checkcid && (PORTAL_SHOP == 1 || $portal == 1))
 			{
 				continue;
 			}


### PR DESCRIPTION
#### Improvements
- Shopper Group acl filter for category was applied in category but after loading all the data. Now, improved code to apply ACL Filter before loading data. This will make improvement for huge sites. 
- To test performance can be checked. It might not show much difference with minor data.

**General Testing Info**
- Go to shopper group and set portal to yes
- Select category which you don't want to allow for specific shopper group
- Login with the user which is in that shopper group
- Notice any failure or performance improvement
