### PR TITLE
REDSHOP-2373 Clears download table which references order IDs

### DIFF
--- a/component/admin/helpers/order.php
+++ b/component/admin/helpers/order.php
@@ -67,6 +67,14 @@ class order_functions
 		$query = 'TRUNCATE TABLE `' . $this->_table_prefix . 'order_payment`';
 		$this->_db->setQuery($query);
 		$this->_db->execute();
+
+		$query = 'TRUNCATE TABLE `' . $this->_table_prefix . 'product_download`';
+		$this->_db->setQuery($query);
+		$this->_db->execute();
+
+		$query = 'TRUNCATE TABLE `' . $this->_table_prefix . 'product_download_log`';
+		$this->_db->setQuery($query);
+		$this->_db->execute();
 	}
 
 	/*


### PR DESCRIPTION
This PR would prevent a huge mess if order IDs are reset and the product download table isn't cleared. It will leave it badly populated and grant access to products to users that shouldn't be allowed to download them, by sending download links in the emails of the first orders.

Please review. Thanks!
