### PR TITLE
REDSHOP-2370 Clear Postdanmark info only when needed

### DIFF
--- a/plugins/redshop_shipping/postdanmark/includes/js/functions.js
+++ b/plugins/redshop_shipping/postdanmark/includes/js/functions.js
@@ -12,7 +12,7 @@ jQuery(document).ready(function() {
         }
     });
 
-    jQuery('input[type="radio"]').click(function() {
+    jQuery('input[type="radio"][id^="shipping_rate_id"]').click(function() {
         if (checkPDinput(jQuery(this))) {
             inject_button(jQuery(this));
         } else {

--- a/plugins/redshop_shipping/postdanmark/postdanmark.xml
+++ b/plugins/redshop_shipping/postdanmark/postdanmark.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="2.5.0" client="site" type="plugin" group="redshop_shipping" method="upgrade">
 	<name>PLG_REDSHOP_SHIPPING_POSTDANMARK</name>
-	<version>1.1</version>
+	<version>1.1.1</version>
     <redshop>1.5</redshop>
 	<creationDate>September 2014</creationDate>
 	<author>redCOMPONENT.com</author>


### PR DESCRIPTION
Information used to get cleared no matter what kind of radio button was clicked. This PR makes it so that it only gets cleared if another shipping method gets selected. Other radio buttons will not affect it.
