### PR TITLE
REDSHOP-2385 Fixing plugin so it's compatible with DX

### DIFF
--- a/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2.xml
+++ b/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2.xml
@@ -33,7 +33,7 @@
                     <option value="0">Total</option>
                 </field>
                 <field name="seller_id" type="text" default=""
-                       label="dibs.com Seller/Vendor ID: " description="DIBS Seller or Vendot ID"/>
+                       label="DIBS Integration ID: " description="DIBS Seller or Vendor ID"/>
                 <field name="dibs_currency" type="list" default="1" label="Currecy: "
                        description="Currency">
                     <option value="DKK" selected="selected">Danish Kroner (DKK)</option>
@@ -61,7 +61,7 @@
                     <option value="0">No</option>
                 </field>
                 <field name="dibs_languages" type="list" default="1"
-                       label="FlexWin Language:" description="Select language for DIBS flexwin">
+                       label="Language:" description="Select language for DIBS interface">
                     <option value="Auto" selected="selected">Auto</option>
                     <option value="da">Danish</option>
                     <option value="sv">Swedish</option>

--- a/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2/extra_info.php
@@ -77,14 +77,13 @@ for ($p = 0; $p < count($order_items); $p++)
 	$product_item_price          = $currencyClass->convert($order_items[$p]->product_item_price, '', $this->params->get("dibs_currency"));
 	$product_item_price_excl_vat = $currencyClass->convert($order_items[$p]->product_item_price_excl_vat, '', $this->params->get("dibs_currency"));
 	$pvat                        = $product_item_price - $product_item_price_excl_vat;
-	$total_amount                = $product_item_price * $order_items[$p]->product_quantity;
 	$product_item_price_excl_vat = floor($product_item_price_excl_vat * 1000) / 1000;
 	$product_item_price_excl_vat = number_format($product_item_price_excl_vat, 2, '.', '') * 100;
 	$pvat                        = floor($pvat * 1000) / 1000;
 	$pvat                        = number_format($pvat, 2, '.', '') * 100;
 
 	// Accumulate total
-	$amount += (float) number_format($total_amount, 2, '.', '') * 100;
+	$amount += ($product_item_price_excl_vat + $pvat) * $order_items[$p]->product_quantity;
 
 	$formdata['oiRow' . ($p + 1) . ''] = $order_items[$p]->product_quantity
 										. ";pcs"

--- a/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2/extra_info.php
@@ -137,7 +137,7 @@ if ($order->order_shipping > 0)
 										. ";" . ($p + 1)
 										. ";" . $shipping_vat;
 	$p++;
-	$amount += $shipping_price + $shipping_vat;
+	$amount += $shipping_price;
 }
 
 $payment_price = $order->payment_discount;

--- a/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2/extra_info.php
@@ -26,9 +26,7 @@ if ($language == "Auto")
 }
 
 // For total amount
-$amount       = $currencyClass->convert($data['carttotal'], '', $this->params->get("dibs_currency"));
-$amount       = floor($amount * 1000) / 1000;
-$amount       = number_format($amount, 2, '.', '') * 100;
+$amount       = 0;
 $paytype      = $this->params->get("dibs_paytype");
 $dibs_paytype = implode(",", $paytype);
 
@@ -79,11 +77,13 @@ for ($p = 0; $p < count($order_items); $p++)
 	$product_item_price          = $currencyClass->convert($order_items[$p]->product_item_price, '', $this->params->get("dibs_currency"));
 	$product_item_price_excl_vat = $currencyClass->convert($order_items[$p]->product_item_price_excl_vat, '', $this->params->get("dibs_currency"));
 	$pvat                        = $product_item_price - $product_item_price_excl_vat;
-	$total_amount                = $product_item_price * $order_items[$p]->quantity;
 	$product_item_price_excl_vat = floor($product_item_price_excl_vat * 1000) / 1000;
 	$product_item_price_excl_vat = number_format($product_item_price_excl_vat, 2, '.', '') * 100;
 	$pvat                        = floor($pvat * 1000) / 1000;
 	$pvat                        = number_format($pvat, 2, '.', '') * 100;
+
+	// Accumulate total
+	$amount += $product_item_price_excl_vat + $pvat;
 
 	$formdata['oiRow' . ($p + 1) . ''] = $order_items[$p]->product_quantity
 										. ";pcs"
@@ -109,6 +109,7 @@ if ($order->order_discount > 0)
 										. ";" . ($p + 1)
 										. ";" . $discount_pvat;
 	$p++;
+	$amount -= $discount_pvat + $discount_amount;
 }
 
 if ($order->order_shipping > 0)
@@ -135,6 +136,7 @@ if ($order->order_shipping > 0)
 										. ";" . ($p + 1)
 										. ";" . $shipping_vat;
 	$p++;
+	$amount += $shipping_price + $shipping_vat;
 }
 
 $payment_price = $order->payment_discount;
@@ -163,14 +165,18 @@ if ($payment_price > 0)
 										. ";" . $discount_payment_price
 										. ";" . ($p + 1)
 										. ";" . $payment_vat;
+
+	$amount += $discount_payment_price + $payment_vat;
 }
+
+$formdata['amount'] = $amount;
 
 include JPATH_SITE . '/plugins/redshop_payment/' . $plugin . '/' . $plugin . '/dibs_hmac.php';
 $dibs_hmac = new dibs_hmac;
 $mac_key   = $dibs_hmac->calculateMac($formdata, $hmac_key);
 
 // Action URL
-$dibsurl = "https://sat1.dibspayment.com/dibspaymentwindow/entrypoint";
+$dibsurl = "https://payment.dibspayment.com/dpw/entrypoint";
 ?>
 <form action="<?php echo $dibsurl ?>" id='dibscheckout' name="dibscheckout" method="post" accept-charset="utf-8">
 	<?php foreach ($formdata as $name => $value): ?>

--- a/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_dibsv2/rs_payment_dibsv2/extra_info.php
@@ -77,13 +77,14 @@ for ($p = 0; $p < count($order_items); $p++)
 	$product_item_price          = $currencyClass->convert($order_items[$p]->product_item_price, '', $this->params->get("dibs_currency"));
 	$product_item_price_excl_vat = $currencyClass->convert($order_items[$p]->product_item_price_excl_vat, '', $this->params->get("dibs_currency"));
 	$pvat                        = $product_item_price - $product_item_price_excl_vat;
+	$total_amount                = $product_item_price * $order_items[$p]->product_quantity;
 	$product_item_price_excl_vat = floor($product_item_price_excl_vat * 1000) / 1000;
 	$product_item_price_excl_vat = number_format($product_item_price_excl_vat, 2, '.', '') * 100;
 	$pvat                        = floor($pvat * 1000) / 1000;
 	$pvat                        = number_format($pvat, 2, '.', '') * 100;
 
 	// Accumulate total
-	$amount += $product_item_price_excl_vat + $pvat;
+	$amount += (float) number_format($total_amount, 2, '.', '') * 100;
 
 	$formdata['oiRow' . ($p + 1) . ''] = $order_items[$p]->product_quantity
 										. ";pcs"


### PR DESCRIPTION
URL change as per these instructions: http://tech.dibspayment.com/dx_convert_from_dpw

The way of determining the total amount of the order changed as we are using a lot of aproximations, and sometimes they don't add up correctly and DIBS complains.

I also changed the strings as the DX platform doesn't offer the Flexwin feature. Including that name would be confusing.
