### PR TITLE
REDSHOP-2396 Fix product name missing on attribute section at stockroom listing page

### DIFF
--- a/component/admin/models/stockroom_listing.php
+++ b/component/admin/models/stockroom_listing.php
@@ -65,7 +65,9 @@ class RedshopModelStockroom_listing extends RedshopModel
 		$db = JFactory::getDbo();
 
 		// Initialize query
-		$query = $db->getQuery(true)->select('p.*');
+		$query = $db->getQuery(true)
+					->select('p.*')
+					->where($db->qn('p.product_id') . ' !=' . $db->q(''));
 
 		$keyword = $this->getState('keyword');
 


### PR DESCRIPTION
Not really sure how to reproduce it in general so can't provide testing info. But I have fixed the problem on lacarla.dk and http://www.br-electronic.dk
