### PR TITLE
REDSHOP-2401 Authorize DPM payment status to verify if transaction approved

### DIFF
--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.php
@@ -116,10 +116,16 @@ class plgRedshop_paymentrs_payment_authorize_dpm extends JPlugin
 		$invalid_status = $this->params->get('invalid_status', '');
 		$cancel_status  = $this->params->get('cancel_status', '');
 
-		if (isset($tid) && $response_code == 1)
+		if ($response_code == 1)
 		{
 			$values->order_status_code = $verify_status;
-			$values->order_payment_status_code = 'Paid';
+			$values->order_payment_status_code = 'Unpaid';
+
+			if (isset($tid))
+			{
+				$values->order_payment_status_code = 'Paid';
+			}
+
 			$values->log = JTEXT::_('COM_REDSHOP_ORDER_PLACED');
 			$values->msg = JTEXT::_('COM_REDSHOP_ORDER_PLACED');
 		}


### PR DESCRIPTION
Setting order status to `Unpaid` is transaction is not approved, but still this is a valid transaction so giving it a verified status. It means, typically when transaction will be approved, order status will be **Confirm** and **Paid** and when transaction is not approved, order status will be **Confirm** and **Unpaid**
