### PR TITLE
REDSHOP-2401 Fixes Authorize DPM payment notifications

### DIFF
--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.php
@@ -116,7 +116,7 @@ class plgRedshop_paymentrs_payment_authorize_dpm extends JPlugin
 		$invalid_status = $this->params->get('invalid_status', '');
 		$cancel_status  = $this->params->get('cancel_status', '');
 
-		if ($response_code == 1)
+		if (isset($tid) && $response_code == 1)
 		{
 			$values->order_status_code = $verify_status;
 			$values->order_payment_status_code = 'Paid';

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.php
@@ -119,12 +119,7 @@ class plgRedshop_paymentrs_payment_authorize_dpm extends JPlugin
 		if ($response_code == 1)
 		{
 			$values->order_status_code = $verify_status;
-			$values->order_payment_status_code = 'Unpaid';
-
-			if (isset($tid))
-			{
-				$values->order_payment_status_code = 'Paid';
-			}
+			$values->order_payment_status_code = 'Paid';
 
 			$values->log = JTEXT::_('COM_REDSHOP_ORDER_PLACED');
 			$values->msg = JTEXT::_('COM_REDSHOP_ORDER_PLACED');

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/extra_info.php
@@ -24,7 +24,7 @@ $login_id         = $this->params->get("access_id");
 $trans_id         = $this->params->get("transaction_id");
 $is_test          = $this->params->get("is_test");
 
-$relay_response_url = JURI::root() . 'index.php?option=com_redshop&view=order_detail&layout=checkout_final&tmpl=component&oid=' . $data["order_id"] . '&encr=' . $data['order']->encr_key . '&Itemid=' . $Itemid;
+$relay_response_url = JURI::root() . 'index.php?option=com_redshop&view=order_detail&layout=checkout_final&stap=2&tmpl=component&oid=' . $data["order_id"] . '&encr=' . $data['order']->encr_key . '&Itemid=' . $Itemid;
 
 $api_login_id    = $login_id;
 $transaction_key = $trans_id;


### PR DESCRIPTION
Fixes both of the issues I mentioned here: https://github.com/redCOMPONENT-COM/redSHOP/pull/1884

The Authorize API will return `1` as the response code if the transaction was successful. The reason we don't receive that parameter is because it's received and processed by this method: https://github.com/redCOMPONENT-COM/redSHOP/blob/e7d0ed366b5b3cdf463cdfa07e1956f7b0ba3c01/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.php#L41

Which is also why we need `stap=2`
