### PR TITLE
REDSHOP-2470 AT-325 Fix Shipping rate priority issue of v1.5.0.5

### DIFF
--- a/component/admin/helpers/shipping.php
+++ b/component/admin/helpers/shipping.php
@@ -13,27 +13,18 @@ JLoader::load('RedshopHelperProduct');
 
 class shipping
 {
-	public $_db;
-
-	public function __construct()
-	{
-		$this->_db = JFactory::getDbo();
-
-		$this->_table_prefix = '#__redshop_';
-		$this->producthelper = new producthelper;
-	}
-
 	/**
 	 *  function ******** To get Shipping rate for cart
 	 */
 	public function getDefaultShipping($d)
 	{
-		$userhelper      = new rsUserhelper;
-		$session         = JFactory::getSession();
-		$order_subtotal  = $d ['order_subtotal'];
-		$user            = JFactory::getUser();
-		$user_id         = $user->id;
-		$db = JFactory::getDbo();
+		$productHelper  = new producthelper;
+		$userhelper     = new rsUserhelper;
+		$session        = JFactory::getSession();
+		$order_subtotal = $d ['order_subtotal'];
+		$user           = JFactory::getUser();
+		$user_id        = $user->id;
+		$db             = JFactory::getDbo();
 
 		$totaldimention  = $this->getCartItemDimention();
 		$weighttotal     = $totaldimention['totalweight'];
@@ -119,7 +110,7 @@ class shipping
 
 				$pwhere    .= ")";
 				$newpwhere = str_replace("AND (", "OR (", $pwhere);
-				$sql       = "SELECT * FROM " . $this->_table_prefix . "shipping_rate as sr "
+				$sql       = "SELECT * FROM #__redshop_shipping_rate as sr "
 							. "LEFT JOIN #__extensions AS s ON sr.shipping_class = s.element
 		 	     				 WHERE s.folder='redshop_shipping' and s.enabled =1  and  $wherecountry
 								 $iswhere
@@ -141,7 +132,7 @@ class shipping
 				for ($i = 0; $i < $idx; $i++)
 				{
 					$product_id = $cart [$i] ['product_id'];
-					$sel = 'SELECT category_id FROM ' . $this->_table_prefix . 'product_category_xref WHERE product_id = ' . (int) $product_id;
+					$sel = 'SELECT category_id FROM #__redshop_product_category_xref WHERE product_id = ' . (int) $product_id;
 					$db->setQuery($sel);
 					$categorydata = $db->loadObjectList();
 					$where = ' ';
@@ -162,7 +153,7 @@ class shipping
 
 						$where .= ")";
 						$newcwhere = str_replace("AND (", "OR (", $where);
-						$sql = "SELECT * FROM " . $this->_table_prefix . "shipping_rate as sr
+						$sql = "SELECT * FROM #__redshop_shipping_rate as sr
 									 LEFT JOIN #__extensions AS s
 									 ON
 									 sr.shipping_class = s.element
@@ -185,7 +176,7 @@ class shipping
 
 			if (!$shippingrate)
 			{
-				$sql = "SELECT * FROM " . $this->_table_prefix . "shipping_rate as sr
+				$sql = "SELECT * FROM #__redshop_shipping_rate as sr
 								 LEFT JOIN #__extensions AS s
 								 ON
 								 sr.shipping_class = s.element
@@ -214,7 +205,7 @@ class shipping
 				if ($shippingrate->apply_vat == 1)
 				{
 					$result = $this->getShippingVatRates($shippingrate->shipping_tax_group_id, $user_id);
-					$addVat = $this->producthelper->taxexempt_addtocart($user_id);
+					$addVat = $productHelper->taxexempt_addtocart($user_id);
 
 					if (!empty($result) && $addVat)
 					{
@@ -243,14 +234,15 @@ class shipping
 	 */
 	public function getDefaultShipping_xmlexport($d)
 	{
+		$productHelper  = new producthelper;
 		$userhelper     = new rsUserhelper;
 		$session        = JFactory::getSession();
 		$order_subtotal = $d ['order_subtotal'];
 		$user           = JFactory::getUser();
 		$user_id        = $user->id;
-		$db = JFactory::getDbo();
+		$db             = JFactory::getDbo();
 
-		$data           = $this->producthelper->getProductById($d['product_id']);
+		$data           = $productHelper->getProductById($d['product_id']);
 
 		$totalQnt       = '';
 		$weighttotal    = $data->weight;
@@ -326,7 +318,7 @@ class shipping
 			$pwhere = 'AND ( FIND_IN_SET(' . (int) $product_id . ', shipping_rate_on_product) )';
 			$newpwhere = str_replace("AND (", "OR (", $pwhere);
 
-			$sql = "SELECT * FROM " . $this->_table_prefix . "shipping_rate as sr "
+			$sql = "SELECT * FROM #__redshop_shipping_rate as sr "
 				. "LEFT JOIN #__extensions AS s ON sr.shipping_class = s.element
  	     				 WHERE s.folder='redshop_shipping' and  $wherecountry
 						 $iswhere
@@ -345,9 +337,9 @@ class shipping
 			if (!$shippingrate)
 			{
 				$product_id = $cart ['product_id'];
-				$sel = 'SELECT category_id FROM ' . $this->_table_prefix . 'product_category_xref WHERE product_id = ' . (int) $product_id;
-				$this->_db->setQuery($sel);
-				$categorydata = $this->_db->loadObjectList();
+				$sel = 'SELECT category_id FROM #__redshop_product_category_xref WHERE product_id = ' . (int) $product_id;
+				$db->setQuery($sel);
+				$categorydata = $db->loadObjectList();
 				$where = ' ';
 
 				if ($categorydata)
@@ -366,7 +358,7 @@ class shipping
 
 					$where .= ")";
 					$newcwhere = str_replace("AND (", "OR (", $where);
-					$sql = "SELECT * FROM " . $this->_table_prefix . "shipping_rate as sr
+					$sql = "SELECT * FROM #__redshop_shipping_rate as sr
 									 LEFT JOIN #__extensions AS s
 									 ON
 									 sr.shipping_class = s.element
@@ -388,7 +380,7 @@ class shipping
 
 			if (!$shippingrate)
 			{
-				$sql = "SELECT * FROM " . $this->_table_prefix . "shipping_rate as sr
+				$sql = "SELECT * FROM #__redshop_shipping_rate as sr
 								 LEFT JOIN #__extensions AS s
 								 ON
 								 sr.shipping_class = s.element
@@ -417,7 +409,7 @@ class shipping
 				if ($shippingrate->apply_vat == 1)
 				{
 					$result = $this->getShippingVatRates($shippingrate->shipping_tax_group_id, $user_id);
-					$addVat = $this->producthelper->taxexempt_addtocart($user_id);
+					$addVat = $productHelper->taxexempt_addtocart($user_id);
 
 					if (!empty($result) && $addVat)
 					{
@@ -447,14 +439,15 @@ class shipping
 	 */
 	public function getShippingrate_calc()
 	{
-		$country    = JRequest::getVar('country_code');
-		$state      = JRequest::getVar('state_code');
-		$zip        = JRequest::getVar('zip_code');
-		$ordertotal = 0;
-		$rate       = 0;
-		$session    = JFactory::getSession();
-		$cart       = $session->get('cart');
-		$db = JFactory::getDbo();
+		$productHelper = new producthelper;
+		$country       = JRequest::getVar('country_code');
+		$state         = JRequest::getVar('state_code');
+		$zip           = JRequest::getVar('zip_code');
+		$ordertotal    = 0;
+		$rate          = 0;
+		$session       = JFactory::getSession();
+		$cart          = $session->get('cart');
+		$db            = JFactory::getDbo();
 
 		$idx        = (int) ($cart ['idx']);
 
@@ -473,9 +466,9 @@ class shipping
 				$pwhere .= " or ";
 			}
 
-			$sel = 'SELECT category_id FROM ' . $this->_table_prefix . 'product_category_xref WHERE product_id = ' . (int) $product_id;
-			$this->_db->setQuery($sel);
-			$categorydata = $this->_db->loadObjectList();
+			$sel = 'SELECT category_id FROM #__redshop_product_category_xref WHERE product_id = ' . (int) $product_id;
+			$db->setQuery($sel);
+			$categorydata = $db->loadObjectList();
 
 			if ($categorydata)
 			{
@@ -567,7 +560,7 @@ class shipping
 			$wherestate = ' AND (FIND_IN_SET(' . $db->quote($state) . ', shipping_rate_state ) OR shipping_rate_state="0" OR shipping_rate_state="")';
 		}
 
-		$sql = "SELECT shipping_rate_value,shipping_rate_zip_start,shipping_rate_zip_end FROM " . $this->_table_prefix . "shipping_rate as sr
+		$sql = "SELECT shipping_rate_value,shipping_rate_zip_start,shipping_rate_zip_end FROM #__redshop_shipping_rate as sr
 				LEFT JOIN #__extensions AS s
 				ON
 				sr.shipping_class = s.element WHERE 1=1 and s.folder='redshop_shipping'  and
@@ -584,9 +577,9 @@ class shipping
 
 				ORDER BY shipping_rate_priority ,shipping_rate_value, sr.shipping_rate_id ";
 
-		$this->_db->setQuery($sql);
+		$db->setQuery($sql);
 
-		$shippingrate = $this->_db->loadObjectlist();
+		$shippingrate = $db->loadObjectlist();
 
 		/**
 		 * rearrange shipping rates array
@@ -662,8 +655,8 @@ class shipping
 
 		$total = $cart['total'] - $cart['shipping'] + $rate;
 
-		$rate  = $this->producthelper->getProductFormattedPrice($rate, true);
-		$total = $this->producthelper->getProductFormattedPrice($total, true);
+		$rate  = $productHelper->getProductFormattedPrice($rate, true);
+		$total = $productHelper->getProductFormattedPrice($total, true);
 
 		return $rate . "`" . $total;
 	}
@@ -717,10 +710,12 @@ class shipping
 
 	public function getShippingAddress($user_info_id)
 	{
-		$query = 'SELECT * FROM ' . $this->_table_prefix . 'users_info '
+		$db = JFactory::getDbo();
+
+		$query = 'SELECT * FROM #__redshop_users_info '
 			. 'WHERE users_info_id = ' .(int) $user_info_id;
-		$this->_db->setQuery($query);
-		$result = $this->_db->loadObject();
+		$db->setQuery($query);
+		$result = $db->loadObject();
 
 		return $result;
 	}
@@ -754,7 +749,7 @@ class shipping
 	public function getShippingRates($shipping_class)
 	{
 		$db = JFactory::getDbo();
-		$query = "SELECT * FROM " . $this->_table_prefix . "shipping_rate "
+		$query = "SELECT * FROM #__redshop_shipping_rate "
 			. "WHERE shipping_class = " . $db->quote($shipping_class);
 		$db->setQuery($query);
 		$result = $db->loadObjectlist();
@@ -764,12 +759,13 @@ class shipping
 
 	public function applyVatOnShippingRate($shippingrate = array(), $user_id)
 	{
+		$productHelper     = new producthelper;
 		$shipping_rate_vat = $shippingrate->shipping_rate_value;
 
 		if ($shippingrate->apply_vat == 1)
 		{
 			$result = $this->getShippingVatRates($shippingrate->shipping_tax_group_id, $user_id);
-			$addVat = $this->producthelper->taxexempt_addtocart($user_id);
+			$addVat = $productHelper->taxexempt_addtocart($user_id);
 
 			if (!empty($result) && $addVat)
 			{
@@ -903,9 +899,9 @@ class shipping
 			for ($i = 0; $i < $idx; $i++)
 			{
 				$product_id = $cart [$i] ['product_id'];
-				$sel = 'SELECT category_id FROM ' . $this->_table_prefix . 'product_category_xref WHERE product_id = ' . (int) $product_id;
-				$this->_db->setQuery($sel);
-				$categorydata = $this->_db->loadObjectList();
+				$sel = 'SELECT category_id FROM #__redshop_product_category_xref WHERE product_id = ' . (int) $product_id;
+				$db->setQuery($sel);
+				$categorydata = $db->loadObjectList();
 
 				if ($categorydata)
 				{
@@ -937,7 +933,7 @@ class shipping
 				OR (shipping_rate_zip_start = "" AND shipping_rate_zip_end = "") ) ';
 			}
 
-			$sql = "SELECT * FROM " . $this->_table_prefix . "shipping_rate WHERE shipping_class = " . $db->quote($shipping_class) . "
+			$sql = "SELECT * FROM #__redshop_shipping_rate WHERE shipping_class = " . $db->quote($shipping_class) . "
 				$wherecountry $wherestate $whereshopper
 				$zipCond
 				AND (( '$volume' BETWEEN shipping_rate_volume_start AND shipping_rate_volume_end) OR (shipping_rate_volume_end = 0) )
@@ -1028,9 +1024,10 @@ class shipping
 
 	public function getShippingVatRates($shipping_tax_group_id, $user_id = 0)
 	{
-		$user    = JFactory::getUser();
-		$session = JFactory::getSession();
-		$db = JFactory::getDbo();
+		$productHelper = new producthelper;
+		$user          = JFactory::getUser();
+		$session       = JFactory::getSession();
+		$db            = JFactory::getDbo();
 
 		if ($user_id == 0)
 		{
@@ -1042,7 +1039,7 @@ class shipping
 
 		if ($user_id)
 		{
-			$userdata = $this->producthelper->getUserInformation($user_id);
+			$userdata = $productHelper->getUserInformation($user_id);
 
 			if (count($userdata) > 0)
 			{
@@ -1083,8 +1080,8 @@ class shipping
 
 			if ($users_info_id && (REGISTER_METHOD == 1 || REGISTER_METHOD == 2) && (VAT_BASED_ON == 2 || VAT_BASED_ON == 1))
 			{
-				$query = "SELECT country_code,state_code FROM " . $this->_table_prefix . "users_info AS u "
-					. "LEFT JOIN " . $this->_table_prefix . "shopper_group AS sh ON sh.shopper_group_id=u.shopper_group_id "
+				$query = "SELECT country_code,state_code FROM #__redshop_users_info AS u "
+					. "LEFT JOIN #__redshop_shopper_group AS sh ON sh.shopper_group_id=u.shopper_group_id "
 					. "WHERE u.users_info_id = " . (int) $users_info_id . " "
 					. "order by u.users_info_id ASC LIMIT 0,1";
 				$db->setQuery($query);
@@ -1098,7 +1095,7 @@ class shipping
 		}
 		elseif ($shipping_tax_group_id > 0)
 		{
-			$q2 = 'LEFT JOIN ' . $this->_table_prefix . 'shipping_rate as s on tr.tax_group_id=s.shipping_tax_group_id ';
+			$q2 = 'LEFT JOIN #__redshop_shipping_rate as s on tr.tax_group_id=s.shipping_tax_group_id ';
 			$and .= 'AND s.shipping_tax_group_id = ' . (int) $shipping_tax_group_id . ' ';
 		}
 		else
@@ -1106,7 +1103,7 @@ class shipping
 			$and .= 'AND tr.tax_group_id = ' . (int) DEFAULT_VAT_GROUP . ' ';
 		}
 
-		$query = 'SELECT tr.* FROM ' . $this->_table_prefix . 'tax_rate as tr '
+		$query = 'SELECT tr.* FROM #__redshop_tax_rate as tr '
 			. $q2
 			. 'WHERE ( tr.tax_country = ' . $db->quote($userdata->country_code) . ' or tr.tax_country = "") '
 			. 'AND ( tr.tax_state = ' . $db->quote($userdata->state_code) . ' or tr.tax_state = "")'
@@ -1120,8 +1117,9 @@ class shipping
 
 	public function getShopperGroupDefaultShipping($user_id = 0)
 	{
-		$shippingArr = array();
-		$user        = JFactory::getUser();
+		$productHelper = new producthelper;
+		$shippingArr   = array();
+		$user          = JFactory::getUser();
 
 		// FOR OFFLINE ORDER
 		if ($user_id == 0)
@@ -1131,7 +1129,7 @@ class shipping
 
 		if ($user_id)
 		{
-			$result = $this->producthelper->getUserInformation($user_id);
+			$result = $productHelper->getUserInformation($user_id);
 
 			if (count($result) > 0 && $result->default_shipping == 1)
 			{
@@ -1221,9 +1219,10 @@ class shipping
 	 */
 	public function getProductVolumeShipping()
 	{
-		$session  = JFactory::getSession();
-		$cart     = $session->get('cart');
-		$idx      = (int) ($cart ['idx']);
+		$productHelper = new producthelper;
+		$session       = JFactory::getSession();
+		$cart          = $session->get('cart');
+		$idx           = (int) ($cart ['idx']);
 
 		$length   = array();
 		$width    = array();
@@ -1246,7 +1245,7 @@ class shipping
 				continue;
 			}
 
-			$data       = $this->producthelper->getProductById($cart [$i] ['product_id']);
+			$data       = $productHelper->getProductById($cart [$i] ['product_id']);
 
 			$length[$i] = $data->product_length;
 			$width[$i]  = $data->product_width;
@@ -1330,9 +1329,10 @@ class shipping
 
 	public function getCartItemDimention()
 	{
-		$session = JFactory::getSession();
-		$cart    = $session->get('cart');
-		$idx     = (int) ($cart ['idx']);
+		$productHelper = new producthelper;
+		$session       = JFactory::getSession();
+		$cart          = $session->get('cart');
+		$idx           = (int) ($cart ['idx']);
 
 		$totalQnt    = 0;
 		$totalWeight = 0;
@@ -1348,7 +1348,7 @@ class shipping
 				continue;
 			}
 
-			$data       = $this->producthelper->getProductById($cart [$i] ['product_id']);
+			$data       = $productHelper->getProductById($cart [$i] ['product_id']);
 			$acc_weight = 0;
 
 			if (isset($cart[$i]['cart_accessory']) && count($cart[$i]['cart_accessory']) > 0)
@@ -1358,7 +1358,7 @@ class shipping
 					$acc_id     = $cart[$i]['cart_accessory'][$a]['accessory_id'];
 					$acc_qty    = $cart[$i]['cart_accessory'][$a]['accessory_quantity'];
 
-					if ($acc_data   = $this->producthelper->getProductById($acc_id))
+					if ($acc_data   = $productHelper->getProductById($acc_id))
 					{
 						$acc_weight += ($acc_data->weight * $acc_qty);
 					}
@@ -1419,7 +1419,7 @@ class shipping
 			$whereShippingVolume .= " ) ";
 		}
 
-		$query = "SELECT * FROM " . $this->_table_prefix . "shipping_boxes "
+		$query = "SELECT * FROM #__redshop_shipping_boxes "
 			. "WHERE published = 1 "
 			. $whereShippingVolume
 			. " ORDER BY shipping_box_priority ASC ";
@@ -1438,15 +1438,17 @@ class shipping
 	 */
 	public function getBoxDimensions($boxid = 0)
 	{
+		$db = JFactory::getDbo();
+
 		$whereShippingBoxes = array();
 
 		if ($boxid)
 		{
-			$query = "SELECT * FROM " . $this->_table_prefix . "shipping_boxes "
+			$query = "SELECT * FROM #__redshop_shipping_boxes "
 				. "WHERE published = 1 "
 				. "AND shipping_box_id = " . (int) $boxid;
-			$this->_db->setQuery($query);
-			$box_detail = $this->_db->loadObject();
+			$db->setQuery($query);
+			$box_detail = $db->loadObject();
 
 			if (count($box_detail) > 0)
 			{
@@ -1535,7 +1537,7 @@ class shipping
 			$whereShippingVolume .= " ) ";
 		}
 
-		$query = "SELECT * FROM " . $this->_table_prefix . "shipping_rate "
+		$query = "SELECT * FROM #__redshop_shipping_rate "
 			. "WHERE (shipping_class = 'default_shipping' OR shipping_class = 'shipper') "
 			. "AND ((" . $db->quote($volume) . " BETWEEN shipping_rate_volume_start AND shipping_rate_volume_end) OR (shipping_rate_volume_end = 0) ) "
 			. "AND ((" . $db->quote($order_subtotal) . " BETWEEN shipping_rate_ordertotal_start AND shipping_rate_ordertotal_end)  OR (shipping_rate_ordertotal_end = 0)) "
@@ -1610,7 +1612,7 @@ class shipping
 				. "OR (shipping_rate_zip_start='' AND shipping_rate_zip_end='') ) ";
 		}
 
-		$query = "SELECT * FROM " . $this->_table_prefix . "shipping_rate "
+		$query = "SELECT * FROM #__redshop_shipping_rate "
 			. "WHERE (shipping_class = 'default_shipping' OR shipping_class = 'shipper') "
 			. $wherecountry
 			. $wherestate
@@ -1631,6 +1633,7 @@ class shipping
 
 	public function isProductDetailMatch(&$d)
 	{
+		$db = JFactory::getDbo();
 		$session = JFactory::getSession();
 		$cart    = $session->get('cart');
 		$idx     = (int) ($cart['idx']);
@@ -1661,9 +1664,9 @@ class shipping
 		for ($i = 0; $i < $idx; $i++)
 		{
 			$product_id = $cart[$i]['product_id'];
-			$sel = 'SELECT category_id FROM ' . $this->_table_prefix . 'product_category_xref WHERE product_id = ' . (int) $product_id;
-			$this->_db->setQuery($sel);
-			$categorydata = $this->_db->loadObjectList();
+			$sel = 'SELECT category_id FROM #__redshop_product_category_xref WHERE product_id = ' . (int) $product_id;
+			$db->setQuery($sel);
+			$categorydata = $db->loadObjectList();
 
 			for ($c = 0; $c < count($categorydata); $c++)
 			{
@@ -1677,12 +1680,12 @@ class shipping
 			$cwhere = ' OR (' . $acwhere . ')';
 		}
 
-		$query = "SELECT * FROM " . $this->_table_prefix . "shipping_rate "
+		$query = "SELECT * FROM #__redshop_shipping_rate "
 			. "WHERE (shipping_class = 'default_shipping' OR shipping_class = 'shipper') "
 			. "AND (shipping_rate_on_product = '' $pwhere) AND (shipping_rate_on_category = '' $cwhere ) "
 			. "ORDER BY shipping_rate_priority ";
-		$this->_db->setQuery($query);
-		$shippingrate = $this->_db->loadObjectList();
+		$db->setQuery($query);
+		$shippingrate = $db->loadObjectList();
 
 		if (count($shippingrate) > 0)
 		{
@@ -1694,10 +1697,11 @@ class shipping
 
 	public function getfreeshippingRate($shipping_rate_id = 0)
 	{
-		$userhelper = new rsUserhelper;
-		$session    = JFactory::getSession();
-		$cart       = $session->get('cart', null);
-		$db = JFactory::getDbo();
+		$productHelper = new producthelper;
+		$userhelper    = new rsUserhelper;
+		$session       = JFactory::getSession();
+		$cart          = $session->get('cart', null);
+		$db            = JFactory::getDbo();
 
 		$idx = 0;
 
@@ -1804,7 +1808,7 @@ class shipping
 			$where .= ' AND sr.shipping_rate_id = ' . (int) $shipping_rate_id . ' ';
 		}
 
-		$sql = "SELECT * FROM " . $this->_table_prefix . "shipping_rate as sr
+		$sql = "SELECT * FROM #__redshop_shipping_rate as sr
 								 LEFT JOIN #__extensions AS s
 								 ON
 								 sr.shipping_class = s.element
@@ -1821,7 +1825,7 @@ class shipping
 			if ($shippingrate->shipping_rate_ordertotal_start > $order_subtotal)
 			{
 				$diff = $shippingrate->shipping_rate_ordertotal_start - $order_subtotal;
-				$text = sprintf(JText::_('COM_REDSHOP_SHIPPING_TEXT_LBL'), $this->producthelper->getProductFormattedPrice($diff));
+				$text = sprintf(JText::_('COM_REDSHOP_SHIPPING_TEXT_LBL'), $productHelper->getProductFormattedPrice($diff));
 			}
 
 			elseif ($shippingrate->shipping_rate_ordertotal_start <= $order_subtotal

--- a/component/admin/helpers/shipping.php
+++ b/component/admin/helpers/shipping.php
@@ -1198,20 +1198,15 @@ class shipping
 	 */
 	public function filter_by_priority($shippingRates)
 	{
-		if ($shippingRates && count($shippingRates))
-		{
-			$priority = array();
+		$shippingRates = array();
 
-			foreach ($shippingRates as $oneRate)
+		for ($i = 0, $j = 0, $ni = count($shippingrate); $i < $ni; $i++)
+		{
+			if ($shippingrate[0]->shipping_rate_priority == $shippingrate[$i]->shipping_rate_priority)
 			{
-				$priority[] = $oneRate->shipping_rate_priority;
+				$shippingRates[$j] = $shippingrate[$i];
+				$j++;
 			}
-
-			array_multisort($priority, SORT_DESC, $shippingRates);
-		}
-		else
-		{
-			$shippingRates = array();
 		}
 
 		return $shippingRates;

--- a/component/admin/helpers/shipping.php
+++ b/component/admin/helpers/shipping.php
@@ -1010,7 +1010,7 @@ class shipping
 
 			if ($is_admin == false)
 			{
-				$shipping = $this->filter_by_priority($shipping);
+				$shipping = self::filterRatesByPriority($shipping);
 			}
 
 			return $shipping;
@@ -1019,7 +1019,7 @@ class shipping
 		{
 			if ($is_admin == false)
 			{
-				$shippingrate = $this->filter_by_priority($shippingrate);
+				$shippingrate = self::filterRatesByPriority($shippingrate);
 			}
 
 			return $shippingrate;
@@ -1190,26 +1190,28 @@ class shipping
 	}
 
 	/**
-	 * Filter by priority
+	 * Filter Shipping rates based on their priority
+	 * Only show Higher priority rates (In [1,2,3,4] take 1 as a high priority)
+	 * Rates with same priority will shown as radio button list in checkout
 	 *
 	 * @param   array  $shippingRates  Array shipping rates
 	 *
 	 * @return array
 	 */
-	public function filter_by_priority($shippingRates)
+	public static function filterRatesByPriority($shippingRates)
 	{
-		$shippingRates = array();
+		$filteredRates = array();
 
-		for ($i = 0, $j = 0, $ni = count($shippingrate); $i < $ni; $i++)
+		for ($i = 0, $j = 0, $ni = count($shippingRates); $i < $ni; $i++)
 		{
-			if ($shippingrate[0]->shipping_rate_priority == $shippingrate[$i]->shipping_rate_priority)
+			if ($shippingRates[0]->shipping_rate_priority == $shippingRates[$i]->shipping_rate_priority)
 			{
-				$shippingRates[$j] = $shippingrate[$i];
+				$filteredRates[$j] = $shippingRates[$i];
 				$j++;
 			}
 		}
 
-		return $shippingRates;
+		return $filteredRates;
 	}
 
 	/*


### PR DESCRIPTION
Fix issue generated because of https://github.com/redCOMPONENT-COM/redSHOP/pull/1813

It is a general bug and produced in 1.5.0.5 release by following commits https://github.com/shandak/redSHOP/commit/79b6e03a09e468343353c9a22bc1a18987ff84d7
Rolled backed function public function filter_by_priority($shippingRates)` https://github.com/shandak/redSHOP/commit/79b6e03a09e468343353c9a22bc1a18987ff84d7#diff-f42bd2f7321cc4c1c981d44811a2e8edR1199
#### Testing Info
- Go through task for more info on this.
#### How shipping rate priority works!
- We are filtering (not sorting) rates based on priority set in shipping rate.
- Only show Higher priority rates (In [1,2,3,4] take 1 as a high priority)
- Rates with same priority will shown as radio button list in checkout
