### PR TITLE
REDSHOP-2482 Unset from array only when ALL is found

### DIFF
--- a/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
+++ b/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
@@ -87,9 +87,9 @@ class PlgRedshop_Paymentrs_Payment_Epayv2 extends JPlugin
 			$unsetIndex = array_search('ALL', $cardTypes);
 
 			if ($unsetIndex !== false)
-            {
+			{
 				unset($cardTypes[$unsetIndex]);
-            }
+			}
 
 			$formdata['paymenttype'] = implode(',', $cardTypes);
 		}

--- a/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
+++ b/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
@@ -84,7 +84,10 @@ class PlgRedshop_Paymentrs_Payment_Epayv2 extends JPlugin
 		if ($cardTypes = $this->params->get('paymenttype'))
 		{
 			// Remove ALL keyword
-			unset($cardTypes[array_search('ALL', $cardTypes)]);
+			$unsetIndex = array_search('ALL', $cardTypes);
+
+			if ($unsetIndex !== false)
+				unset($cardTypes[$unsetIndex]);
 
 			$formdata['paymenttype'] = implode(',', $cardTypes);
 		}

--- a/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
+++ b/plugins/redshop_payment/rs_payment_epayv2/rs_payment_epayv2.php
@@ -87,7 +87,9 @@ class PlgRedshop_Paymentrs_Payment_Epayv2 extends JPlugin
 			$unsetIndex = array_search('ALL', $cardTypes);
 
 			if ($unsetIndex !== false)
+            {
 				unset($cardTypes[$unsetIndex]);
+            }
 
 			$formdata['paymenttype'] = implode(',', $cardTypes);
 		}


### PR DESCRIPTION
`array_search` was returning a non-boolean `false` value which the PHP evaluated to `0` when used as an index. This caused the plugin to _always_ delete the item at the first index if "ALL" wasn't found.
