### PR TITLE
REDSHOP-2483 Fix redshop_product plugin not loading constants and config

### DIFF
--- a/plugins/content/redshop_product/redshop_product.php
+++ b/plugins/content/redshop_product/redshop_product.php
@@ -30,7 +30,16 @@ class plgContentredshop_product extends JPlugin
 			JHTML::_('behavior.modal');
 
 			$session = JFactory::getSession();
-			$post = JRequest::get('POST');
+			$post    = JRequest::get('POST');
+			$option  = JRequest::getCmd('option');
+
+			if ($option != 'com_redshop')
+			{
+				require_once JPATH_ADMINISTRATOR . '/components/com_redshop/helpers/redshop.cfg.php';
+				JLoader::load('RedshopHelperAdminConfiguration');
+				$Redconfiguration = new Redconfiguration;
+				$Redconfiguration->defineDynamicVars();
+			}
 
 			if (isset($post['product_currency']))
 			{


### PR DESCRIPTION
This fixes both issues reported at the JIRA page:
- Adding to cart not working
- Huge amount of warnings about undefined constants
