### PR TITLE
Adding Gulp - New build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ phing-latest.phar
 
 # Gulp Build script
 gulp-config.json
+npm-debug.log
 node_modules/
 
 # Composer

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ Desktop.ini
 build.properties
 phing-latest.phar
 
+# Gulp Build script
+gulp-config.json
+node_modules/
+
 # Composer
 composer.lock
 composer.phar

--- a/README.md
+++ b/README.md
@@ -13,6 +13,35 @@ Please follow the next steps in order to release a new version of redSHOP.
 
 - Execute component_packager.xml PHING file to generate the main component package (includes 1 module and 2 plugins).
 
+### Using Gulp build system
+#### Following tasks and switches are available:
+
+Use this command to release component.
+Version and other information can be set in `gulp-config.json` file.
+
+    gulp release:component
+
+This command is to release the extensions.
+
+    gulp release:extensions
+
+
+This command will read the base directory and create zip files for each of the folder.
+
+#### === Switches ===
+Pass an argument to choose different folder
+
+    --folder {source direcory}  Default: "./plugins"
+
+Pass an argument to change suffix for extension
+
+    --suffix {text of suffix}   Default: "plg_"
+
+#### Example Usage:
+
+	 gulp release:extensions --folder ./modules --suffix ext_
+
+
 ### Languages & translation
 - Move the language files to the translations repository: https://github.com/redCOMPONENT-COM/translations/tree/master/redSHOP/source
 - Check in 24hours that Transifex was able to get the new translation strings adding them to the .ini resource files

--- a/gulp-config.sample.json
+++ b/gulp-config.sample.json
@@ -1,9 +1,9 @@
 {
-	"releasePkgName": "redshop_",
-	"packageDir"    : "/var/www/packages",
-	"version"       : "1.5.0.5.2",
-	"joomlaVersion" : "j25-j3x",
-	"packageFiles"  :[
+	"name"         : "redshop_",
+	"releasesDir"  : "/var/www/releases",
+	"version"      : "1.5.0.5.2",
+	"joomlaVersion": "j25-j3x",
+	"packageFiles" :[
 		"LICENSE.txt",
 		"redshop.xml",
 		"install.php",

--- a/gulp-config.sample.json
+++ b/gulp-config.sample.json
@@ -1,7 +1,6 @@
 {
-	"name"         : "redshop_",
+	"name"         : "redshop",
 	"releasesDir"  : "/var/www/releases",
-	"version"      : "1.5.0.5.2",
 	"joomlaVersion": "j25-j3x",
 	"packageFiles" :[
 		"LICENSE.txt",

--- a/gulp-config.sample.json
+++ b/gulp-config.sample.json
@@ -1,0 +1,19 @@
+{
+	"releasePkgName": "redshop_",
+	"packageDir"    : "/var/www/packages",
+	"version"       : "1.5.0.5.2",
+	"joomlaVersion" : "j25-j3x",
+	"packageFiles"  :[
+		"LICENSE.txt",
+		"redshop.xml",
+		"install.php",
+		"component/**",
+		"media/**",
+		"libraries/**",
+		"modules/site/mod_redshop_cart/**",
+		"plugins/system/redshop/**",
+		"plugins/redshop_payment/rs_payment_banktransfer/**",
+		"plugins/redshop_payment/rs_payment_paypal/**",
+		"plugins/redshop_shipping/default_shipping/**"
+	]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,13 +23,13 @@ extensionConfig = require('./package.json')
 manifest = {},
 
 // Init component version - Set default as config version
-redshop = {"version":'',"compatibility":'',"pluginVersion":''};
+component = {"version":'',"compatibility":'',"pluginVersion":''};
 
 // Reading manifest file
-readManifest('./redshop.xml');
+readManifest('./' + config.name + '.xml');
 
 // Update version from manifest file
-redshop.version = manifest.extension.version[0];
+component.version = manifest.extension.version[0];
 
 function getFolders(dir) {
 	return fs.readdirSync(dir)
@@ -79,28 +79,29 @@ gulp.task('release:extensions', function() {
 
 		tasks = plugins.map(function(plugin) {
 
-			var pluginBasePath = path.join(srcFolder, folder, plugin);
+			var pluginBasePath = path.join(srcFolder, folder, plugin),
+			componentName = config.name;
 
 			// Reading manifest file
 			readManifest(path.join(pluginBasePath, plugin + '.xml'));
 
 			// Update version from manifest file
-			redshop.pluginVersion = manifest.extension.version[0];
-			redshop.compatibility = (manifest.extension.redshop) ? '_for_redSHOP_' + manifest.extension.redshop[0] : '';
+			component.pluginVersion = manifest.extension.version[0];
+			component.compatibility = (manifest.extension.componentName) ? '_for_' + config.name + '_' + manifest.extension.componentName[0] : '';
 
 			// Strip group name for modules
 			var extGroupName = ('site' == folder) ? '' : folder + '_',
-			destFolderName = 'redshop-' + redshop.version + '-' + srcFolder.split(path.sep)[1];
+			destFolderName = config.name + '-' + component.version + '-' + srcFolder.split(path.sep)[1];
 
 			// Print current extension name
-			gutil.log(gutil.colors.red.bold.italic('-' + plugin + ' v' + redshop.pluginVersion));
+			gutil.log(gutil.colors.red.bold.italic('-' + plugin + ' v' + component.pluginVersion));
 
 			return gulp.src(
 					path.join(pluginBasePath, '**')
 				)
 				.pipe(
 					zip(
-						extSuffix + extGroupName + plugin + '_' + redshop.pluginVersion + redshop.compatibility + '.zip'
+						extSuffix + extGroupName + plugin + '_' + component.pluginVersion + component.compatibility + '.zip'
 					)
 				)
 				.pipe(
@@ -129,10 +130,10 @@ gulp.task('release:component', function() {
 	}
 
 	// Start up log
-	gutil.log(gutil.colors.white.bgGreen('Preparing release for version' + redshop.version));
+	gutil.log(gutil.colors.white.bgGreen('Preparing release for version' + component.version));
 
 	gulp.src(config.packageFiles, {base: '.'})
-		.pipe(zip(config.name + 'v' + redshop.version + '_' + config.joomlaVersion + '.zip'))
+		.pipe(zip(config.name + '_v' + component.version + '_' + config.joomlaVersion + '.zip'))
 		.pipe(gulp.dest(config.releasesDir));
 
 	gutil.log(gutil.colors.white.bgGreen('Component packages are ready at ' + config.releasesDir));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,12 +67,12 @@ gulp.task('release:extensions', function() {
 				)
 			    .pipe(
 			    	zip(
-			    		extSuffix + config.releasePkgName + plugin + '_' + 'v' + config.version + '.zip'
+			    		extSuffix + config.name + plugin + '_' + 'v' + config.version + '.zip'
 			    	)
 			    )
 				.pipe(
 					gulp.dest(
-						path.join(config.packageDir, srcFolder.split(path.sep)[1], folder)
+						path.join(config.releasesDir, srcFolder.split(path.sep)[1], folder)
 					)
 				);
 		});
@@ -98,10 +98,10 @@ gulp.task('release:component', function() {
 	gutil.log(gutil.colors.white.bgGreen('Preparing release for component'));
 
 	gulp.src(config.packageFiles, {base: '.'})
-		.pipe(zip(config.releasePkgName + 'v' + config.version + '_' + config.joomlaVersion + '.zip'))
-		.pipe(gulp.dest(config.packageDir));
+		.pipe(zip(config.name + 'v' + config.version + '_' + config.joomlaVersion + '.zip'))
+		.pipe(gulp.dest(config.releasesDir));
 
-	gutil.log(gutil.colors.white.bgGreen('Component packages are ready at ' + config.packageDir))
+	gutil.log(gutil.colors.white.bgGreen('Component packages are ready at ' + config.releasesDir));
 });
 
 gulp.task(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,21 +8,34 @@ gutil = require('gulp-util')
 //notify = require("gulp-notify"),
 
 // File systems
-fs    = require('fs'),
-path  = require('path'),
-merge = require('merge-stream'),
+fs          = require('fs'),
+path        = require('path'),
+merge       = require('merge-stream'),
+parseString = require('xml2js').parseString,
 
 // Gulp Configuration
 config = require('./gulp-config.json')
 
 // Extension Configuration file
-extensionConfig = require('./package.json');
+extensionConfig = require('./package.json')
+
+// Init manifest file JSON Object
+manifest = {},
+
+// Init component version - Set default as config version
+redshop = {"version":'',"compatibility":'',"pluginVersion":''};
+
+// Reading manifest file
+readManifest('./redshop.xml');
+
+// Update version from manifest file
+redshop.version = manifest.extension.version[0];
 
 function getFolders(dir) {
-    return fs.readdirSync(dir)
-      .filter(function(file) {
-        return fs.statSync(path.join(dir, file)).isDirectory();
-      });
+	return fs.readdirSync(dir)
+		.filter(function(file) {
+			return fs.statSync(path.join(dir, file)).isDirectory();
+	});
 }
 
 function showHelp(){
@@ -31,6 +44,12 @@ function showHelp(){
 			'\n\n\nFollowing tasks and switches are available:\n\n\t 1. gulp release:component \n\t\t Use this command to release component. Version and other information can be set in gulp-config.json file. \n\n\t 2. gulp release:extensions \n\t\t This command is to release the extensions.\n\t\t This command will read the base directory and create zip files for each of the folder. \n\t\t === Switches === \n\t --folder {source direcory}  Default: "./plugins" \n\t --suffix {text of suffix}   Default: "plg_"\n\n\t Example Usage: \n\t\t gulp release:extensions --folder ./modules --suffix ext_ \n\n\n'
 		)
 	);
+}
+
+function readManifest(xml){
+	return parseString(fs.readFileSync(xml, 'ascii'), function (err, result) {
+		manifest = result;
+	});
 }
 
 // Creating zip files for  Extensions
@@ -43,7 +62,7 @@ gulp.task('release:extensions', function() {
 	folders = getFolders(srcFolder),
 
 	// Extension package name suffix
-	extSuffix = gutil.env.suffix || 'plg_';
+	extSuffix = gutil.env.suffix || '';
 
 	// Display log
 	gutil.log(gutil.colors.white.bgBlue(folders.length) + gutil.colors.blue.bold(' extensions are ready for release'));
@@ -60,19 +79,33 @@ gulp.task('release:extensions', function() {
 
 		tasks = plugins.map(function(plugin) {
 
-			gutil.log(gutil.colors.red.bold.italic('-' + plugin));
+			var pluginBasePath = path.join(srcFolder, folder, plugin);
+
+			// Reading manifest file
+			readManifest(path.join(pluginBasePath, plugin + '.xml'));
+
+			// Update version from manifest file
+			redshop.pluginVersion = manifest.extension.version[0];
+			redshop.compatibility = (manifest.extension.redshop) ? '_for_redSHOP_' + manifest.extension.redshop[0] : '';
+
+			// Strip group name for modules
+			var extGroupName = ('site' == folder) ? '' : folder + '_',
+			destFolderName = 'redshop-' + redshop.version + '-' + srcFolder.split(path.sep)[1];
+
+			// Print current extension name
+			gutil.log(gutil.colors.red.bold.italic('-' + plugin + ' v' + redshop.pluginVersion));
 
 			return gulp.src(
-					path.join(srcFolder, folder, plugin, '**')
+					path.join(pluginBasePath, '**')
 				)
-			    .pipe(
-			    	zip(
-			    		extSuffix + config.name + plugin + '_' + 'v' + config.version + '.zip'
-			    	)
-			    )
+				.pipe(
+					zip(
+						extSuffix + extGroupName + plugin + '_' + redshop.pluginVersion + redshop.compatibility + '.zip'
+					)
+				)
 				.pipe(
 					gulp.dest(
-						path.join(config.releasesDir, srcFolder.split(path.sep)[1], folder)
+						path.join(config.releasesDir, destFolderName, folder)
 					)
 				);
 		});
@@ -95,10 +128,11 @@ gulp.task('release:component', function() {
 		return false;
 	}
 
-	gutil.log(gutil.colors.white.bgGreen('Preparing release for component'));
+	// Start up log
+	gutil.log(gutil.colors.white.bgGreen('Preparing release for version' + redshop.version));
 
 	gulp.src(config.packageFiles, {base: '.'})
-		.pipe(zip(config.name + 'v' + config.version + '_' + config.joomlaVersion + '.zip'))
+		.pipe(zip(config.name + 'v' + redshop.version + '_' + config.joomlaVersion + '.zip'))
 		.pipe(gulp.dest(config.releasesDir));
 
 	gutil.log(gutil.colors.white.bgGreen('Component packages are ready at ' + config.releasesDir));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,119 @@
+var gulp = require('gulp'),
+
+// ZIP compress files
+zip = require('gulp-zip'),
+
+// Utility functions for gulp plugins
+gutil = require('gulp-util')
+//notify = require("gulp-notify"),
+
+// File systems
+fs    = require('fs'),
+path  = require('path'),
+merge = require('merge-stream'),
+
+// Gulp Configuration
+config = require('./gulp-config.json')
+
+// Extension Configuration file
+extensionConfig = require('./package.json');
+
+function getFolders(dir) {
+    return fs.readdirSync(dir)
+      .filter(function(file) {
+        return fs.statSync(path.join(dir, file)).isDirectory();
+      });
+}
+
+function showHelp(){
+	gutil.log(
+		gutil.colors.white.bold.bgMagenta(
+			'\n\n\nFollowing tasks and switches are available:\n\n\t 1. gulp release:component \n\t\t Use this command to release component. Version and other information can be set in gulp-config.json file. \n\n\t 2. gulp release:extensions \n\t\t This command is to release the extensions.\n\t\t This command will read the base directory and create zip files for each of the folder. \n\t\t === Switches === \n\t --folder {source direcory}  Default: "./plugins" \n\t --suffix {text of suffix}   Default: "plg_"\n\n\t Example Usage: \n\t\t gulp release:extensions --folder ./modules --suffix ext_ \n\n\n'
+		)
+	);
+}
+
+// Creating zip files for  Extensions
+gulp.task('release:extensions', function() {
+
+	// Source directory for read and prepare for zip
+	var srcFolder = gutil.env.folder || './plugins',
+
+	// Read all the folders in given source directory
+	folders = getFolders(srcFolder),
+
+	// Extension package name suffix
+	extSuffix = gutil.env.suffix || 'plg_';
+
+	// Display log
+	gutil.log(gutil.colors.white.bgBlue(folders.length) + gutil.colors.blue.bold(' extensions are ready for release'));
+
+	// Loop through the folders and create zip files for each of them.
+	var tasks;
+
+	folders.map(function(folder) {
+
+		var plugins = getFolders(path.join(srcFolder, folder));
+
+		// Display name of the folder
+		gutil.log(gutil.colors.blue.bold.italic(folder + ' (' + plugins.length + ')'));
+
+		tasks = plugins.map(function(plugin) {
+
+			gutil.log(gutil.colors.red.bold.italic('-' + plugin));
+
+			return gulp.src(
+					path.join(srcFolder, folder, plugin, '**')
+				)
+			    .pipe(
+			    	zip(
+			    		extSuffix + config.releasePkgName + plugin + '_' + 'v' + config.version + '.zip'
+			    	)
+			    )
+				.pipe(
+					gulp.dest(
+						path.join(config.packageDir, srcFolder.split(path.sep)[1], folder)
+					)
+				);
+		});
+	});
+
+	return merge(tasks);
+});
+
+// Creating zip files for Component
+gulp.task('release:component', function() {
+
+	if (!config.packageFiles || (config.packageFiles && config.packageFiles.length <= 0))
+	{
+		gutil.log(
+			gutil.colors.white.bgRed(
+				'ERROR: Please specify `packageFiles` in gulp-config.json or make sure you have added files list'
+			)
+		);
+
+		return false;
+	}
+
+	gutil.log(gutil.colors.white.bgGreen('Preparing release for component'));
+
+	gulp.src(config.packageFiles, {base: '.'})
+		.pipe(zip(config.releasePkgName + 'v' + config.version + '_' + config.joomlaVersion + '.zip'))
+		.pipe(gulp.dest(config.packageDir));
+
+	gutil.log(gutil.colors.white.bgGreen('Component packages are ready at ' + config.packageDir))
+});
+
+gulp.task(
+	'release',
+	[
+		'release:component',
+		'release:extensions'
+	],
+	function() {
+
+});
+
+gulp.task('default', function() {
+	showHelp();
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "gulp-util": "^3.0.4",
     "gulp-zip": "^3.0.2",
     "merge-stream": "^0.1.7",
-    "path": "^0.11.14"
+    "path": "^0.11.14",
+    "xml2js": "^0.4.8"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "redSHOP",
+  "version": "1.5.0",
+  "description": "Release script for redSHOP",
+  "main": "gulpfile.js",
+  "dependencies": {
+    "gulp": "^3.8.11"
+  },
+  "devDependencies": {
+    "fs": "0.0.2",
+    "gulp": "^3.8.11",
+    "gulp-notify": "^2.2.0",
+    "gulp-util": "^3.0.4",
+    "gulp-zip": "^3.0.2",
+    "merge-stream": "^0.1.7",
+    "path": "^0.11.14"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/redCOMPONENT-COM/redSHOP.git"
+  },
+  "keywords": [
+    "joomla",
+    "ecommerce",
+    "redshop"
+  ],
+  "author": "redCOMPONENT-COM",
+  "license": "GPLv2",
+  "bugs": {
+    "url": "https://redweb.atlassian.net/secure/RapidBoard.jspa?rapidView=42&projectKey=REDSHOP"
+  }
+}


### PR DESCRIPTION
### Using Gulp build system
#### Install

To install all the dependencies,

```
sudo npm install
```
#### Following tasks and switches are available:

Use this command to release component.
Version and other information can be set in `gulp-config.json` file.

```
gulp release:component
```

This command is to release the extensions.

```
gulp release:extensions
```

This command will read the base directory and create zip files for each of the folder.
#### Switches

Pass an argument to choose different folder

```
--folder {source direcory}  Default: "./plugins"
```

Pass an argument to change suffix for extension

```
--suffix {text of suffix}   Default: "plg_"
```
#### Example Usage:

```
 gulp release:extensions --folder ./modules --suffix ext_
```
#### Help

```
gulp -h
```
#### Benefits
- compared to phing, gulp is faster.
- Here are the difference:

Gulp is a lot faster (means we can save time in travis build)

| Time | Gulp | Phing |
| --- | --- | --- |
| Component | 10 milliseconds | 3.8602 seconds |
| Plugin | 612 milliseconds | 2.2526 seconds |
| Module | 410 milliseconds | 738.3 milliseconds |
#### Output

![gulp-vs-phing1](https://cloud.githubusercontent.com/assets/2002921/7745873/e669ccf4-ffcb-11e4-8cd5-43ce19fdb98f.png)
![gulp-vs-phing](https://cloud.githubusercontent.com/assets/2002921/7745872/e6698fbe-ffcb-11e4-97eb-78f1a921808a.png)

Note: This is just a fist base and it needs few enhancements to match output with current phing build. For example: choosing redshop and extension version in phing is dynamic here it is static. This can be done somehow. but it's future task. :)
