### PR TITLE
[gulp] Using joomla-gulp-release package for redSHOP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ Desktop.ini
 build.properties
 phing-latest.phar
 
+# Gulp Build script
+gulp-config.json
+npm-debug.log
+node_modules/
+
 # Composer
 composer.lock
 composer.phar

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Please follow the next steps in order to release a new version of redSHOP.
 - Execute component_packager.xml PHING file to generate the main component package (includes 1 module and 2 plugins).
 
 ### Using Gulp build system
+
+Before you can run any Gulp command you need to:
+
+- download and install NodeJS https://nodejs.org/download/
+- install npm: `sudo npm install`
+- install Gulp: `npm install --save gulp-install`
+
 #### Following tasks and switches are available:
 
 Use this command to release component.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,35 @@ Please follow the next steps in order to release a new version of redSHOP.
 
 - Execute component_packager.xml PHING file to generate the main component package (includes 1 module and 2 plugins).
 
+### Using Gulp build system
+#### Following tasks and switches are available:
+
+Use this command to release component.
+Version and other information can be set in `gulp-config.json` file.
+
+    gulp release:component
+
+This command is to release the extensions.
+
+    gulp release:extensions
+
+
+This command will read the base directory and create zip files for each of the folder.
+
+#### === Switches ===
+Pass an argument to choose different folder
+
+    --folder {source direcory}  Default: "./plugins"
+
+Pass an argument to change suffix for extension
+
+    --suffix {text of suffix}   Default: "plg_"
+
+#### Example Usage:
+
+	 gulp release:extensions --folder ./modules --suffix ext_
+
+
 ### Languages & translation
 - Move the language files to the translations repository: https://github.com/redCOMPONENT-COM/translations/tree/master/redSHOP/source
 - Check in 24hours that Transifex was able to get the new translation strings adding them to the .ini resource files

--- a/gulp-config.sample.json
+++ b/gulp-config.sample.json
@@ -1,0 +1,18 @@
+{
+	"name"         : "redshop",
+	"releasesDir"  : "/var/www/releases",
+	"joomlaVersion": "j25-j3x",
+	"packageFiles" :[
+		"LICENSE.txt",
+		"redshop.xml",
+		"install.php",
+		"component/**",
+		"media/**",
+		"libraries/**",
+		"modules/site/mod_redshop_cart/**",
+		"plugins/system/redshop/**",
+		"plugins/redshop_payment/rs_payment_banktransfer/**",
+		"plugins/redshop_payment/rs_payment_paypal/**",
+		"plugins/redshop_shipping/default_shipping/**"
+	]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,1 @@
+var jgulp = require('joomla-gulp-release');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "redSHOP",
+  "version": "1.5.0",
+  "description": "Release script for redSHOP",
+  "main": "gulpfile.js",
+  "dependencies": {},
+  "devDependencies": {
+    "gulp": "^3.8.11",
+    "joomla-gulp-release": "^1.0.3"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/redCOMPONENT-COM/redSHOP.git"
+  },
+  "keywords": [
+    "joomla",
+    "ecommerce",
+    "redshop"
+  ],
+  "author": "redCOMPONENT-COM",
+  "license": "GPLv2",
+  "bugs": {
+    "url": "https://redweb.atlassian.net/secure/RapidBoard.jspa?rapidView=42&projectKey=REDSHOP"
+  }
+}


### PR DESCRIPTION
Using common package `joomla-gulp-release` https://www.npmjs.com/package/joomla-gulp-release for redshop. 

https://github.com/redCOMPONENT-COM/redSHOP/pull/1920 PR is not needed now.
#### To Release `component` and create `.zip` file

> Use this command to release component. Version and other information can be set in `gulp-config.json` file.

```
gulp release:component
```
#### To Release `modules` and create `.zip` file

```
gulp release:modules
```
#### To Release `plugins` and create `.zip` file

```
gulp release:plugins
```
#### To Release `packages` and create `.zip` file

```
gulp release:packages
```

_or_

```
gulp release:packages --folder ./individual_package_dir
```
