### PR TITLE
QA-22 Allow to execute one test each time in robo

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -218,7 +218,7 @@ class RoboFile extends \Robo\Tasks
             }
             $this->say('');
             $testNumber = $this->ask('Type the number of the test  in the list that you want to run...');
-            $pathToTestFile = 'tests/acceptance/' . $tests[$testNumber];
+            $pathToTestFile = "tests/$suite/" . $tests[$testNumber];
         }
 
         $this->taskCodecept()

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -19,7 +19,7 @@ class RoboFile extends \Robo\Tasks
     /**
      * Current RoboFile version
      */
-    private $version = '1.2';
+    private $version = '1.3';
 
     /**
      * Hello World example task.
@@ -160,4 +160,87 @@ class RoboFile extends \Robo\Tasks
             ->stopOnFail();
     }
 
+    /**
+     * Executes Selenium System Tests in your machine
+     *
+     * @param null $seleniumPath   Optional path to selenium-standalone-server-x.jar
+     * @param null $pathToTestFile Optional name of the test to be run
+     *
+     * @return mixed
+     */
+    public function runTest($seleniumPath = null, $pathToTestFile = null)
+    {
+        if (!$seleniumPath) {
+            if (!file_exists('selenium-server-standalone.jar')) {
+                $this->say('Downloading Selenium Server, this may take a while.');
+                $this->taskExec('wget')
+                     ->arg('http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar')
+                     ->arg('-O selenium-server-standalone.jar')
+                     ->printed(false)
+                     ->run();
+            }
+            $seleniumPath = 'selenium-server-standalone.jar';
+        }
+
+        // Make sure we have Composer
+        if (!file_exists('./composer.phar')) {
+            $this->_exec('curl -sS https://getcomposer.org/installer | php');
+        }
+        $this->taskComposerUpdate()->run();
+
+        // Running Selenium server
+        $this->_exec("java -jar $seleniumPath > selenium-errors.log 2>selenium.log &");
+
+        $this->taskWaitForSeleniumStandaloneServer()
+             ->run()
+             ->stopOnFail();
+
+        // Make sure to Run the Build Command to Generate AcceptanceTester
+        $this->_exec("php vendor/bin/codecept build");
+
+        if (!$pathToTestFile)
+        {
+            $this->say('Available tests in the system:');
+            $testFiles = scandir(getcwd() . '/tests/acceptance');
+            foreach ($testFiles as $number => $testFileName)
+            {
+                if (strripos($testFileName, 'cept.php') || strripos($testFileName, 'cest.php'))
+                {
+                    $this->say('[' . $number . '] ' . $testFileName);
+                }
+            }
+            $this->say('');
+            $testNumber = $this->ask('Type the number of the test  in the list that you want to run...');
+            $pathToTestFile = 'tests/acceptance/' . $testFiles[$testNumber];
+        }
+
+        $this->taskCodecept()
+             ->test($pathToTestFile)
+             ->arg('--steps')
+             ->arg('--debug')
+             ->run()
+             ->stopOnFail();
+
+        // Kill selenium server
+        // $this->_exec('curl http://localhost:4444/selenium-server/driver/?cmd=shutDownSeleniumServer');
+
+        $this->say('Printing Selenium Log files');
+        $this->say('------ selenium-errors.log (start) ---------');
+        $seleniumErrors = file_get_contents('selenium-errors.log');
+        if ($seleniumErrors) {
+            $this->say(file_get_contents('selenium-errors.log'));
+        }
+        else {
+            $this->say('no errors were found');
+        }
+        $this->say('------ selenium-errors.log (end) -----------');
+
+        /*
+        // Uncomment if you need to debug issues in selenium
+        $this->say('');
+        $this->say('------ selenium.log (start) -----------');
+        $this->say(file_get_contents('selenium.log'));
+        $this->say('------ selenium.log (end) -----------');
+        */
+    }
 }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -163,12 +163,13 @@ class RoboFile extends \Robo\Tasks
     /**
      * Executes Selenium System Tests in your machine
      *
-     * @param null $seleniumPath   Optional path to selenium-standalone-server-x.jar
-     * @param null $pathToTestFile Optional name of the test to be run
+     * @param string $seleniumPath   Optional path to selenium-standalone-server-x.jar
+     * @param string $pathToTestFile Optional name of the test to be run
+     * @param string $suite          Optional name of the suite containing the tests, Acceptance by default.
      *
      * @return mixed
      */
-    public function runTest($seleniumPath = null, $pathToTestFile = null)
+    public function runTest($seleniumPath = null, $pathToTestFile = null, $suite = 'acceptance')
     {
         if (!$seleniumPath) {
             if (!file_exists('selenium-server-standalone.jar')) {
@@ -200,18 +201,24 @@ class RoboFile extends \Robo\Tasks
 
         if (!$pathToTestFile)
         {
+            $tests = array();
             $this->say('Available tests in the system:');
-            $testFiles = scandir(getcwd() . '/tests/acceptance');
-            foreach ($testFiles as $number => $testFileName)
+            $filesInSuite = scandir(getcwd() . '/tests/' . $suite);
+
+            $i = 1;
+            foreach ($filesInSuite as $file)
             {
-                if (strripos($testFileName, 'cept.php') || strripos($testFileName, 'cest.php'))
+                // Make sure the file is a Test file
+                if (strripos($file, 'cept.php') || strripos($file, 'cest.php'))
                 {
-                    $this->say('[' . $number . '] ' . $testFileName);
+                    $tests[$i] = $file;
+                    $this->say('[' . $i . '] ' . $file);
+                    $i++;
                 }
             }
             $this->say('');
             $testNumber = $this->ask('Type the number of the test  in the list that you want to run...');
-            $pathToTestFile = 'tests/acceptance/' . $testFiles[$testNumber];
+            $pathToTestFile = 'tests/acceptance/' . $tests[$testNumber];
         }
 
         $this->taskCodecept()


### PR DESCRIPTION
@puneet0191 please review and merge if looks okay. 

I build this script to help me testing pulls like your https://github.com/redCOMPONENT-COM/redSHOP/pull/1955

What it does is to add a new command in ROBO. Now you can do:

`vendor/bin/robo run:test``

that will show a numerical list of all the available tests in the Acceptance suite:

![screen shot 2015-06-05 at 12 44 23](https://cloud.githubusercontent.com/assets/1375475/8004430/12817fa2-0b80-11e5-80de-7f053204eda4.png)

The CLI will ask you to tell witch test do you want to run, just typing the number:

![screen shot 2015-06-05 at 12 57 31](https://cloud.githubusercontent.com/assets/1375475/8004627/9b4448d2-0b81-11e5-8569-81877f504222.png)

That way you can easily run individual tests
