### PR TITLE
REDSHOP-2525 Fixed discount not getting category restricted

### DIFF
--- a/component/site/helpers/product.php
+++ b/component/site/helpers/product.php
@@ -288,7 +288,8 @@ class producthelper
 				->select('dp.*')
 				->from($db->qn('#__redshop_discount_product', 'dp'))
 				->where('dp.published = 1')
-				->where('(dp.discount_product_id IN (' . implode(',', $discountIds) . ') OR FIND_IN_SET("' . implode(',', $catIds) . '", dp.category_ids))')
+				->where('(dp.discount_product_id IN (' . implode(',', $discountIds) . ')')
+				->where('FIND_IN_SET("' . implode(',', $catIds) . '", dp.category_ids))')
 				->where('dp.start_date <= ' . $db->q($time))
 				->where('dp.end_date >= ' . $db->q($time))
 				->order('dp.amount DESC');


### PR DESCRIPTION
Whenever a massive discount was created and a category was selected to restrict said discount, it wouldn't restrict at all, and the discount would get applied regardless of the category the product belonged to.
