### PR TITLE
REDSHOP-2385 REDSHOP-2559 Fix MAC verification in J2.5

### DIFF
--- a/plugins/redshop_payment/dibsv2/dibsv2.php
+++ b/plugins/redshop_payment/dibsv2/dibsv2.php
@@ -85,7 +85,8 @@ class PlgRedshop_PaymentDibsv2 extends JPlugin
 		// Calculate the MAC for the form key-values posted from DIBS.
 		if ($request)
 		{
-			$MAC = $dibs_hmac->calculateMac($request->getArray(), $HmacKey);
+			// Getting the array of post values is done this way to maintain compatibility with J2.5. J3 supports using simply `$post->getArray()`
+			$MAC = $dibs_hmac->calculateMac($request->getArray(array_flip(array_keys($_POST))), $HmacKey);
 
 			if ($request->getString('MAC') == $MAC && $request->getString('status') == "ACCEPTED")
 			{


### PR DESCRIPTION
Sadly, this seems to be the only simply (yet still convoluted) way to keep J2.5 compatibility for this particular thing. Otherwise the MAC check will fail. More discussion here:
https://redweb.slack.com/archives/redcomponent-dev/p1435327179000360
