### PR TITLE
REDSHOP-2513 add PHP requirement note in Braintree

### DIFF
--- a/plugins/redshop_payment/rs_payment_braintree/language/en-GB/en-GB.plg_redshop_payment_rs_payment_braintree.ini
+++ b/plugins/redshop_payment/rs_payment_braintree/language/en-GB/en-GB.plg_redshop_payment_rs_payment_braintree.ini
@@ -1,5 +1,5 @@
 PLG_RS_PAYMENT_BRAINTREE="Braintree Payments"
-PLG_RS_PAYMENT_BRAINTREE_DESC="This plugin enables standard BrainTree payments for redSHOP"
+PLG_RS_PAYMENT_BRAINTREE_DESC="This plugin enables standard BrainTree payments for redSHOP<br/><br/><div class="alert alert-warning"><h4 class="alert-heading">Important note:</h4><p class="alert-message">Braintree requires PHP 5.5 or above in your server</p></div>"
 PLG_RS_PAYMENT_BRAINTREE_PAYMENT_OPRAND_LBL="Payment operand"
 PLG_RS_PAYMENT_BRAINTREE_PAYMENT_PRICE_LBL="Payment price"
 PLG_RS_PAYMENT_BRAINTREE_PAYMENT_DISCOUNT_IS_PERCENT_LBL="Discount Type"

--- a/plugins/redshop_payment/rs_payment_braintree/language/en-GB/en-GB.plg_redshop_payment_rs_payment_braintree.sys.ini
+++ b/plugins/redshop_payment/rs_payment_braintree/language/en-GB/en-GB.plg_redshop_payment_rs_payment_braintree.sys.ini
@@ -1,3 +1,3 @@
 PLG_RS_PAYMENT_BRAINTREE="Braintree Payments"
-PLG_RS_PAYMENT_BRAINTREE_DESC="This plugin enables standard BrainTree payments for redSHOP"
+PLG_RS_PAYMENT_BRAINTREE_DESC="This plugin enables standard BrainTree payments for redSHOP<br/><br/><div class="alert alert-warning"><h4 class="alert-heading">Important note:</h4><p class="alert-message">Braintree requires PHP 5.5 or above in your server</p></div>"
 

--- a/plugins/redshop_payment/rs_payment_braintree/rs_payment_braintree.xml
+++ b/plugins/redshop_payment/rs_payment_braintree/rs_payment_braintree.xml
@@ -9,7 +9,7 @@
     <authorUrl>http://www.redcomponent.com</authorUrl>
     <copyright>redCOMPONENT.com</copyright>
     <license>GNU General Public License v2</license>
-    <description>PLG_RS_PAYMENT_BRAINTREE_DESC</description>
+    <description><![CDATA[PLG_RS_PAYMENT_BRAINTREE_DESC]]></description>
 
     <files>
         <filename plugin="rs_payment_braintree">rs_payment_braintree.php</filename>


### PR DESCRIPTION
based on https://redweb.atlassian.net/browse/REDSHOP-2513 I'm adding this note when installing:

![screen shot 2015-07-02 at 17 14 06](https://cloud.githubusercontent.com/assets/1375475/8480270/0e04d02e-20dd-11e5-941e-b86dd114f275.png)

in 2.5:

![screen shot 2015-07-02 at 17 14 42](https://cloud.githubusercontent.com/assets/1375475/8480277/1466f028-20dd-11e5-8259-c9a913133786.png)
