### PR TITLE
AT-340 Adding JPagination link layout for javascript link bug in frontend

### DIFF
--- a/component/site/layouts/joomla/pagination/link.php
+++ b/component/site/layouts/joomla/pagination/link.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+$item = $displayData['data'];
+
+$display = $item->text;
+
+switch ((string) $item->text)
+{
+	// Check for "Start" item
+	case JText::_('JLIB_HTML_START') :
+		$icon = "icon-backward";
+		break;
+
+	// Check for "Prev" item
+	case $item->text == JText::_('JPREV') :
+		$item->text = JText::_('JPREVIOUS');
+		$icon = "icon-step-backward";
+		break;
+
+	// Check for "Next" item
+	case JText::_('JNEXT') :
+		$icon = "icon-step-forward";
+		break;
+
+	// Check for "End" item
+	case JText::_('JLIB_HTML_END') :
+		$icon = "icon-forward";
+		break;
+
+	default:
+		$icon = null;
+		break;
+}
+
+if ($icon !== null)
+{
+	$display = '<span class="' . $icon . '"></span>';
+}
+
+if ($displayData['active'])
+{
+	if ($item->base > 0)
+	{
+		$limit = 'limitstart.value=' . $item->base;
+	}
+	else
+	{
+		$limit = 'limitstart.value=0';
+	}
+
+	$cssClasses = array();
+
+	$title = '';
+
+	if (!is_numeric($item->text))
+	{
+		JHtml::_('bootstrap.tooltip');
+		$cssClasses[] = 'hasTooltip';
+		$title = ' title="' . $item->text . '" ';
+	}
+
+	$onClick = '';
+	$href    = $item->link;
+
+	// Still using javascript approach in backend
+	if (JFactory::getApplication()->isAdmin())
+	{
+		$onClick = 'onclick="document.adminForm.' . $item->prefix . 'limitstart.value=' . ($item->base > 0 ? $item->base : '0') . '; Joomla.submitform();return false;"';
+		$href    = '#';
+	}
+}
+else
+{
+	$class = (property_exists($item, 'active') && $item->active) ? 'active' : 'disabled';
+}
+?>
+<?php if ($displayData['active']) : ?>
+	<li>
+		<a
+			<?php echo !empty($cssClasses) ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?>
+			<?php echo $title; ?>
+			<?php echo $onClick; ?>
+			href="<?php echo $href; ?>"
+		>
+			<?php echo $display; ?>
+		</a>
+	</li>
+<?php else : ?>
+	<li class="<?php echo $class; ?>">
+		<span><?php echo $display; ?></span>
+	</li>
+<?php endif;


### PR DESCRIPTION
### Problem

When using `getListFooter` in frontend, having issue in pagination link. 
#### For Example:

If we use,

```
echo $this->pagination->getListFooter();
```

_Note: Layout or pagination file should not be overrided_
### How to reproduce

To reproduce this issue can manually use above function in code or if you are using `JPagination` in your component you may check there. 

_There are many other ways to fix it by overriding `JPagination` class and `JLayout` but I think this should be fix in core too._
