### PR TITLE
REDSHOP-2587 Changed URL to benefit from hosting change

### DIFF
--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.xml
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
 	<name>PLG_RS_PAYMENT_AUTHORIZE_DPM</name>
-	<version>1.5</version>
+	<version>1.5.1</version>
 	<redshop>1.5</redshop>
 	<creationDate>April 2013</creationDate>
 	<author>redCOMPONENT.com</author>

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetAIM.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetAIM.php
@@ -40,7 +40,7 @@
  */
 class AuthorizeNetAIM extends AuthorizeNetRequest
 {
-	const LIVE_URL = 'https://secure.authorize.net/gateway/transact.dll';
+	const LIVE_URL = 'https://secure2.authorize.net/gateway/transact.dll';
 	const SANDBOX_URL = 'https://test.authorize.net/gateway/transact.dll';
 
 	/**

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetARB.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetARB.php
@@ -15,7 +15,7 @@
  */
 class AuthorizeNetARB extends AuthorizeNetRequest
 {
-	const LIVE_URL = "https://api.authorize.net/xml/v1/request.api";
+	const LIVE_URL = "https://api2.authorize.net/xml/v1/request.api";
 	const SANDBOX_URL = "https://apitest.authorize.net/xml/v1/request.api";
 
 	private $_request_type;

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetCIM.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetCIM.php
@@ -15,7 +15,7 @@
  */
 class AuthorizeNetCIM extends AuthorizeNetRequest
 {
-	const LIVE_URL = "https://api.authorize.net/xml/v1/request.api";
+	const LIVE_URL = "https://api2.authorize.net/xml/v1/request.api";
 	const SANDBOX_URL = "https://apitest.authorize.net/xml/v1/request.api";
 
 	private $_xml;

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetDPM.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetDPM.php
@@ -26,7 +26,7 @@
  */
 class AuthorizeNetDPM extends AuthorizeNetSIM_Form
 {
-	const LIVE_URL = 'https://secure.authorize.net/gateway/transact.dll';
+	const LIVE_URL = 'https://secure2.authorize.net/gateway/transact.dll';
 	const SANDBOX_URL = 'https://test.authorize.net/gateway/transact.dll';
 
 	/**

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetSOAP.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetSOAP.php
@@ -17,8 +17,8 @@
  */
 class AuthorizeNetSOAP extends SoapClient
 {
-	const WSDL_URL = "https://api.authorize.net/soap/v1/Service.asmx?WSDL";
-	const LIVE_URL = "https://api.authorize.net/soap/v1/Service.asmx";
+	const WSDL_URL = "https://api2.authorize.net/soap/v1/Service.asmx?WSDL";
+	const LIVE_URL = "https://api2.authorize.net/soap/v1/Service.asmx";
 	const SANDBOX_URL = "https://apitest.authorize.net/soap/v1/Service.asmx";
 
 	public $sandbox;

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetTD.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/authorize_lib/lib/AuthorizeNetTD.php
@@ -15,7 +15,7 @@
  */
 class AuthorizeNetTD extends AuthorizeNetRequest
 {
-	const LIVE_URL = "https://api.authorize.net/xml/v1/request.api";
+	const LIVE_URL = "https://api2.authorize.net/xml/v1/request.api";
 	const SANDBOX_URL = "https://apitest.authorize.net/xml/v1/request.api";
 
 	private $_xml;

--- a/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_authorize_dpm/rs_payment_authorize_dpm/extra_info.php
@@ -54,7 +54,7 @@ $sim = new AuthorizeNetSIM_Form(
 );
 
 $hidden_fields = $sim->getHiddenFieldString();
-$post_url      = ($is_test ? "https://test.authorize.net/gateway/transact.dll" : "https://secure.authorize.net/gateway/transact.dll");
+$post_url      = ($is_test ? "https://test.authorize.net/gateway/transact.dll" : "https://secure2.authorize.net/gateway/transact.dll");
 
 echo "<h3>" . JText::_('PLG_RS_PAYMENT_AUTHORIZE_DPM_MESSAGE') . "</h3>";
 echo '


### PR DESCRIPTION
Read issue for more info.

The original URL will benefit from the host change as well automatically starting phase 2 (which starts on June 2016) so technically the change isn't necessary.

They do warn about downtime, so I went ahead and made this patch.
