### PR TITLE
REDSHOP-2484 Update encryption method for API v3.00

### DIFF
--- a/plugins/redshop_payment/rs_payment_sagepay/rs_payment_sagepay.xml
+++ b/plugins/redshop_payment/rs_payment_sagepay/rs_payment_sagepay.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_SAGEPAY</name>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
     <redshop>1.5.0.6</redshop>
     <creationDate>April 2013</creationDate>
     <author>redCOMPONENT.com</author>


### PR DESCRIPTION
Updated encryption method as per the details provided in this document (Appendix A1.1):
http://www.sagepay.co.uk/file/21086/download-document/FORM_Integration_and_Protocol_Guidelines_130515.pdf?token=lVuOP5nHq2fMaKPsfJnL_jex5FdNbWw13h-Ig0_BnYw

Testing credentials pending, so consider this a work in progress until we are able to test the patch.
