### PR TITLE
REDSHOP-2605 Extra Field name as column name in product csv export

### DIFF
--- a/component/admin/models/export.php
+++ b/component/admin/models/export.php
@@ -1413,7 +1413,7 @@ class RedshopModelExport extends RedshopModel
 	/**
 	 * Get product extrafields data
 	 *
-	 * @return  array  Extrafields info and product data
+	 * @return  object  Extrafields info and product data
 	 */
 	public static function getProductExtraFields()
 	{
@@ -1439,9 +1439,10 @@ class RedshopModelExport extends RedshopModel
 			}
 		}
 
-		return array(
-			'fields' => array_keys(self::$productExtraFields),
-			'data'   => self::$productExtraFieldsData
-		);
+		$return         = new stdClass;
+		$return->fields = array_keys(self::$productExtraFields);
+		$return->data   = self::$productExtraFieldsData;
+
+		return $return;
 	}
 }

--- a/component/admin/models/export.php
+++ b/component/admin/models/export.php
@@ -21,6 +21,20 @@ JLoader::load('RedshopHelperProduct');
 class RedshopModelExport extends RedshopModel
 {
 	/**
+	 * Contains product extrafield data
+	 *
+	 * @var  array
+	 */
+	public static $productExtraFieldsData = array();
+
+	/**
+	 * Product Extrafields Name
+	 *
+	 * @var  array
+	 */
+	public static $productExtraFields = array();
+
+	/**
 	 * Get export data
 	 *
 	 * @return  void
@@ -157,10 +171,21 @@ class RedshopModelExport extends RedshopModel
 				'download_alternattext')
 		);
 
-		if ($export_product_extra_field = $jInput->getInt('export_product_extra_field', 0))
+		// Product extra fields data
+		if ($exportProductExtraField = $jInput->getInt('export_product_extra_field', 0))
 		{
-			$headers = array_merge($headers, array('extra_fields'));
+			// Load all product extrafield information
+			self::getProductExtraFields();
+
+			$fieldHeader = array_keys(self::$productExtraFields);
+
+			// Append Extra Fields name in header
+			$headers = array_merge(
+				$headers,
+				$fieldHeader
+			);
 		}
+
 
 		$export = array();
 
@@ -307,55 +332,16 @@ class RedshopModelExport extends RedshopModel
 				$oneProduct->download_alternattext = implode("#", $downloadArr['alternate_text']);
 			}
 
-			// Product extra fields data
-			if ($export_product_extra_field)
+			if ($exportProductExtraField)
 			{
-				$query->clear()
-					->select('f.*')
-					->from($db->qn('#__redshop_fields', 'f'))
-					->leftJoin($db->qn('#__redshop_fields_data', 'fd') . ' ON fd.fieldid = f.field_id')
-					->where('fd.itemid = ' . (int) $oneProduct->product_id)
-					->where('fd.section = 1')
-					->order('f.field_id asc');
-
-				if ($fields = $db->setQuery($query)->loadObjectList('field_id'))
+				foreach ($fieldHeader as $extraFieldName)
 				{
-					$query->clear()
-						->select('fd.*')
-						->from($db->qn('#__redshop_fields_data', 'fd'))
-						->where('fd.itemid = ' . (int) $oneProduct->product_id)
-						->where('fd.section = 1');
+					$oneProduct->$extraFieldName = '';
 
-					if ($fieldsData = $db->setQuery($query)->loadObjectList())
+					if (isset(self::$productExtraFieldsData[(int) $oneProduct->product_id][$extraFieldName]))
 					{
-						foreach ($fieldsData as $fieldData)
-						{
-							$fields[$fieldData->fieldid]->data = $fieldData;
-						}
+						$oneProduct->$extraFieldName = self::$productExtraFieldsData[(int) $oneProduct->product_id][$extraFieldName]->data_txt;
 					}
-
-					$query->clear()
-						->select('fv.*')
-						->from($db->qn('#__redshop_fields_value', 'fv'))
-						->leftJoin($db->qn('#__redshop_fields_data', 'fd') . ' ON fd.fieldid = fv.field_id')
-						->where('fd.itemid = ' . (int) $oneProduct->product_id)
-						->where('fd.section = 1')
-						->order('fv.value_id ASC');
-
-					if ($fieldValue = $db->setQuery($query)->loadObjectList())
-					{
-						foreach ($fieldValue as $oneValue)
-						{
-							if (!isset($fields[$oneValue->field_id]->values))
-							{
-								$fields[$oneValue->field_id]->values = array();
-							}
-
-							$fields[$oneValue->field_id]->values[] = $oneValue;
-						}
-					}
-
-					$oneProduct->extra_fields = str_replace('"', '_EE_', json_encode($fields));
 				}
 			}
 
@@ -1422,5 +1408,40 @@ class RedshopModelExport extends RedshopModel
 		$db->setQuery($query);
 
 		return $db->loadObjectlist();
+	}
+
+	/**
+	 * Get product extrafields data
+	 *
+	 * @return  array  Extrafields info and product data
+	 */
+	public static function getProductExtraFields()
+	{
+		if (empty(self::$productExtraFields))
+		{
+			$db = JFactory::getDbo();
+
+			$query = $db->getQuery(true)
+					->select('f.*, fd.*')
+					->from($db->qn('#__redshop_fields', 'f'))
+					->leftJoin($db->qn('#__redshop_fields_data', 'fd') . ' ON fd.fieldid = f.field_id')
+					->where('fd.section = 1')
+					->order('f.field_id asc');
+
+			$fields = $db->setQuery($query)->loadObjectList();
+
+			for ($i = 0, $n = count($fields); $i < $n; $i++)
+			{
+				$field = $fields[$i];
+
+				self::$productExtraFields[$field->field_name] = $field->field_name;
+				self::$productExtraFieldsData[$field->itemid][$field->field_name] = $field;
+			}
+		}
+
+		return array(
+			'fields' => array_keys(self::$productExtraFields),
+			'data'   => self::$productExtraFieldsData
+		);
 	}
 }


### PR DESCRIPTION
After this patch product csv will look like below, extra fields for product name will be shown as a column name. 

| product_number | rs_field1 | rs_field2 |
| --- | --- | --- |
| 1 | xyz | abc |
| 2 | google | android |

Note: This is not new feature. This was there before in redSHOP. But it got replaced by rewrite in #1364
