### PR TITLE
BLUELINE-29 #comment Support PDF libraries, which use namespaces

### DIFF
--- a/libraries/redshop/helper/pdf.php
+++ b/libraries/redshop/helper/pdf.php
@@ -45,11 +45,17 @@ class RedshopHelperPdf
 	 */
 	public static function getInstance($client = 'tcpdf', $options = array())
 	{
-		$className = strtoupper($client);
+		$className = $client;
 
 		if (!class_exists($className))
 		{
 			JLoader::import(strtolower($client) . '.library');
+
+			// If in library use namespace or difference class - we can set right class here
+			if (defined(strtoupper($client) . '_LIBRARY_CLASS'))
+			{
+				$className = constant(strtoupper($client) . '_LIBRARY_CLASS');
+			}
 		}
 
 		if (class_exists($className))
@@ -69,9 +75,9 @@ class RedshopHelperPdf
 				$options['format'] = 'A5';
 			}
 
-			if (JLoader::import('helper.' . strtolower($className), JPATH_REDSHOP_LIBRARY))
+			if (JLoader::import('helper.' . strtolower($client), JPATH_REDSHOP_LIBRARY))
 			{
-				$className = 'RedshopHelper' . $className;
+				$className = 'RedshopHelper' . $client;
 			}
 
 			return new $className($options['orientation'], $options['unit'], $options['format']);


### PR DESCRIPTION
I use for project Blueline - Dompdf library, because it library more perfect render html to pdf(it more good render than MPDF too), it support many count css rules http://pxd.me/dompdf/www/examples.php and has good font generator, which support UTF-8. 
It has repo https://github.com/dompdf/dompdf/tree/develop and it a live, so we can include it as submodule.
In the future i think we need use it instead TCPDF, migration to Dompdf must be not a hard and back compability for TCPDF could be stay good too.
I use successfull Dompdf on project SET too.
