### PR TITLE
REDSHOP-2657 [imp] Choosing dynamic helper for pdf library

### DIFF
--- a/libraries/redshop/helper/pdf.php
+++ b/libraries/redshop/helper/pdf.php
@@ -75,9 +75,14 @@ class RedshopHelperPdf
 				$options['format'] = 'A5';
 			}
 
-			if (JLoader::import('helper.' . strtolower($client), JPATH_REDSHOP_LIBRARY))
+			if (!isset($options['helper']))
 			{
-				$className = 'RedshopHelper' . $client;
+				$options['helper'] = $client;
+			}
+
+			if (JLoader::import('helper.' . strtolower($options['helper']), JPATH_REDSHOP_LIBRARY))
+			{
+				$className = 'RedshopHelper' . $options['helper'];
 			}
 
 			return new $className($options['orientation'], $options['unit'], $options['format']);


### PR DESCRIPTION
This change will allow to use different helper if we want.
For example: `tcpdf`
For now there is a default `tcpdf.php` file in which we have called `tcpdf` library. Now, if someone wants to override or want to do something else in helper without doing change in core then.
They can create new file, `customtcpdf.php`
In which,

``` php
class RedshopHelperCustomTcpdf extends TCPDF
{
}
```

and can be used in code - plugin or module,

``` php
RedshopHelperPdf::getInstance('tcpdf', array('helper' => 'customtcpdf'));
```

In this way it will be possible to override tcpdf class in two different ways.
