### PR TITLE
REDSHOP-2860 [cs] Improve code to get order payment detail

### DIFF
--- a/component/admin/controllers/order.php
+++ b/component/admin/controllers/order.php
@@ -148,12 +148,12 @@ class RedshopControllerOrder extends RedshopController
 		{
 			$order_id = JRequest::getCmd('order_id');
 			$order_function = new order_functions;
-			$paymentInfo = $order_function->getOrderPaymentDetail($order_id);
+			$paymentInfo = RedshopHelperOrder::getPaymentInfo($order_id);
 
-			if (count($paymentInfo) > 0)
+			if ($paymentInfo)
 			{
-				$payment_name = $paymentInfo[0]->payment_method_class;
-				$paymentArr = explode("rs_payment_", $paymentInfo[0]->payment_method_class);
+				$payment_name = $paymentInfo->payment_method_class;
+				$paymentArr = explode("rs_payment_", $paymentInfo->payment_method_class);
 
 				if (count($paymentArr) > 0)
 				{
@@ -161,15 +161,9 @@ class RedshopControllerOrder extends RedshopController
 				}
 
 				$economicdata['economic_payment_method'] = $payment_name;
-				$paymentmethod = $order_function->getPaymentMethodInfo($paymentInfo[0]->payment_method_class);
-
-				if (count($paymentmethod) > 0)
-				{
-					$paymentparams = new JRegistry($paymentmethod[0]->params);
-					$economicdata['economic_payment_terms_id'] = $paymentparams->get('economic_payment_terms_id');
-					$economicdata['economic_design_layout'] = $paymentparams->get('economic_design_layout');
-					$economicdata['economic_is_creditcard'] = $paymentparams->get('is_creditcard');
-				}
+				$economicdata['economic_payment_terms_id'] = $paymentInfo->plugin->params->get('economic_payment_terms_id');
+				$economicdata['economic_design_layout'] = $paymentInfo->plugin->params->get('economic_design_layout');
+				$economicdata['economic_is_creditcard'] = $paymentInfo->plugin->params->get('is_creditcard');
 			}
 
 			$economic = new economic;

--- a/component/admin/helpers/order.php
+++ b/component/admin/helpers/order.php
@@ -1044,22 +1044,30 @@ class order_functions
 		return $list;
 	}
 
+	/**
+	 * Get Order Payment Detail
+	 *
+	 * @param   integer  $order_id          Order Id
+	 * @param   integer  $payment_order_id  Payment order id
+	 *
+	 * @deprecated 1.5   Use RedshopHelperOrder::getPaymentInfo instead
+	 *
+	 * @return  array    order payment info
+	 */
 	public function getOrderPaymentDetail($order_id, $payment_order_id = 0)
 	{
-		$db = JFactory::getDbo();
-
-		$and = '';
-
-		if ($payment_order_id != 0)
+		if (!$payment_order_id)
 		{
-			$and = ' AND payment_order_id = ' . (int) $payment_order_id . ' ';
+			return array(RedshopHelperOrder::getPaymentInfo($order_id));
 		}
+		else
+		{
+			$db = JFactory::getDbo();
+			$query = 'SELECT * FROM #__redshop_order_payment WHERE payment_order_id = ' . (int) $payment_order_id;
+			$db->setQuery($query);
 
-		$query = 'SELECT * FROM #__redshop_order_payment ' . 'WHERE order_id = ' . (int) $order_id . ' ' . $and;
-		$db->setQuery($query);
-		$list = $db->loadObjectlist();
-
-		return $list;
+			return $db->loadObjectlist();
+		}
 	}
 
 	public function getOrderPartialPayment($order_id)

--- a/libraries/redshop/helper/order.php
+++ b/libraries/redshop/helper/order.php
@@ -17,6 +17,13 @@ defined('_JEXEC') or die;
 class RedshopHelperOrder
 {
 	/**
+	 * Order Payment Information
+	 *
+	 * @var  array
+	 */
+	protected static $payment = array();
+
+	/**
 	 * Order Info
 	 *
 	 * @var  array
@@ -260,5 +267,48 @@ class RedshopHelperOrder
 		}
 
 		return self::$allStatus;
+	}
+
+	/**
+	 * Get Order Payment Information
+	 *
+	 * @param   integer  $orderId  Order Id
+	 *
+	 * @return  object   Payment Information for orders
+	 */
+	public static function getPaymentInfo($orderId)
+	{
+		if (!in_array($orderId, self::$payment))
+		{
+			$db    = JFactory::getDbo();
+			$query = $db->getQuery(true)
+						->select('*')
+						->from($db->qn('#__redshop_order_payment'))
+						->where($db->qn('order_id') . ' = ' . (int) $orderId);
+
+			// Set the query and load the result.
+			$db->setQuery($query, 0, 1);
+			self::$payment[$orderId] = $db->loadObject();
+
+			// Check for a database error.
+			if ($db->getErrorNum())
+			{
+				JError::raiseWarning(500, $db->getErrorMsg());
+
+				return null;
+			}
+
+			// Get plugin information
+			$plugin = JPluginHelper::getPlugin(
+						'redshop_payment',
+						self::$payment[$orderId]->payment_method_class
+					);
+			$plugin->params = new JRegistry($plugin->params);
+
+			// Set plugin information
+			self::$payment[$orderId]->plugin = $plugin;
+		}
+
+		return self::$payment[$orderId];
 	}
 }


### PR DESCRIPTION
This PR is improving code style of getting order payment information. 
#### Before

We were using old helper object to get detail and have to **load plugin params additionally**.

``` php
$before = $order_function->getOrderPaymentDetail($order_id);
```
#### Now

We have common function to get order payment information using order id and it will also return plugin params in one same object.

``` php
// Get info
$payment = RedshopHelperOrder::getPaymentInfo($order_id);

// Get plugin params
$payment->plugin->params->get('param_name');
```
