### PR TITLE
REDSHOP-2526 Change redirection url to order receipt for e-commerce tracking

### DIFF
--- a/plugins/redshop_payment/mollieideal/mollieideal.php
+++ b/plugins/redshop_payment/mollieideal/mollieideal.php
@@ -66,7 +66,7 @@ class plgRedshop_paymentMollieideal extends JPlugin
 			$path        = dirname(isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : $_SERVER['PHP_SELF']);
 
 			$webhookUrl  = JUri::base() . "index.php?tmpl=component&option=com_redshop&view=order_detail&task=notify_payment&payment_plugin=mollieideal&orderid=" . $data['order_id'];
-			$redirectUrl = JUri::base() . "index.php?option=com_redshop&view=order_detail&Itemid=" . $app->input->getInt('Itemid') . "&oid=" . $data['order_id'];
+			$redirectUrl = JUri::base() . "index.php?option=com_redshop&view=order_detail&layout=receipt&oid=" . $data['order_id'] . "&Itemid=" . $app->input->getInt('Itemid');
 
 			/*
 			 * Payment parameters:

--- a/plugins/redshop_payment/mollieideal/mollieideal.xml
+++ b/plugins/redshop_payment/mollieideal/mollieideal.xml
@@ -7,7 +7,7 @@
 	method="upgrade"
 >
 	<name>PLG_REDSHOP_PAYMENT_MOLLIEIDEAL</name>
-	<version>1.5.0.5</version>
+	<version>1.5.0.5.1</version>
 	<redshop>1.5.0.5.3</redshop>
 	<creationDate>July 2015</creationDate>
 	<author>redCOMPONENT.com</author>


### PR DESCRIPTION
It's just an improvement to #2045 fix google ecommerce tracking issue.
#### Testing Instructions
- Place an order with this payment plugin
- pay or cancel the amount and make sure you are redirecting to order receipt page after.
