### PR TITLE
REDSHOP-2666 Allow extrafield showing in backend

### DIFF
--- a/component/site/helpers/extra_field.php
+++ b/component/site/helpers/extra_field.php
@@ -890,7 +890,9 @@ class extraField
 				$search     = "{" . $row_data[$i]->field_name . "}";
 			}
 
-			if (count($data_value) != 0 && $published && $field_show_in_front)
+			if (count($data_value) != 0 
+				&& $published 
+				&& ($field_show_in_front || JFactory::getApplication()->isAdmin()))
 			{
 				$displayvalue = '';
 


### PR DESCRIPTION
Allow extra field to show information in backend. Before it was force to show information based on setting. Now, setting of "Show in Front" will be apply only to frontend. Backend will be always visible.
#### Testing info

Not sure what specific test can be done but I have fixed this issue with prispereserren site. May be only code review is enough.
