### PR TITLE
REDSHOP-2659 Fixing Stripe Payment Plugin Test Failure

### DIFF
--- a/tests/acceptance/checkout/ProductsCheckoutSagePayCest.php
+++ b/tests/acceptance/checkout/ProductsCheckoutSagePayCest.php
@@ -138,6 +138,14 @@ class ProductsCheckoutSagePayCest
 		$I->click(['xpath' => "//div[@id='currency_code_chzn']//li[text()='British Pound']"]);
 		$I->click(['xpath' => "//div[@id='toolbar-save']/button"]);
 		$I->see('Configuration Saved', ['id' => 'system-message-container']);
+		$I->amOnPage('/administrator/index.php?option=com_redshop&view=configuration');
+		$I->waitForElement(["xpath" => "//a[text()='Price']"], 10);
+		$I->click(["xpath" => "//a[text()='Price']"]);
+		$I->waitForElement(["id" => "currency_code"], 10);
+		$I->click(['xpath' => "//div[@id='currency_code_chzn']/a/div/b"]);
+		$I->click(['xpath' => "//div[@id='currency_code_chzn']//li[text()='US Dollar']"]);
+		$I->click(['xpath' => "//div[@id='toolbar-save']/button"]);
+		$I->see('Configuration Saved', ['id' => 'system-message-container']);
 	}
 
 	/**


### PR DESCRIPTION
@javigomez I am sending this PR only if https://github.com/redCOMPONENT-COM/redSHOP/pull/2119 doesn't get merge. Please make sure you merge this one because currently when Sagepay test gets executed on Travis, it changes the redSHOP configuration and sets the default currency as 'British Pound' which creates problem for Stripe payment plugin.

Hence I am sending PR to add the code to set the currency back to US Dollars, I am not removing the part where it changes it to British Pound because that gives us one more validation, about redSHOP configuration change. 

See the image of the issue.:
![image](https://cloud.githubusercontent.com/assets/3048593/10520330/38bf64b2-7387-11e5-93ef-f7ad2660ed46.png)
