### PR TITLE
REDSHOP-2684 XTREM-243 Fixed initial blank space in base64 character of shipping methods

### DIFF
--- a/component/site/controllers/checkout.php
+++ b/component/site/controllers/checkout.php
@@ -428,7 +428,7 @@ class RedshopControllerCheckout extends RedshopController
 
 		if (SHIPPING_METHOD_ENABLE)
 		{
-			$shipping_rate_id = JRequest::getVar('shipping_rate_id');
+			$shipping_rate_id = JFactory::getApplication()->input->getString('shipping_rate_id');
 			$shippingdetail   = explode("|", $this->_shippinghelper->decryptShipping(str_replace(" ", "+", $shipping_rate_id)));
 
 			if (count($shippingdetail) < 4)


### PR DESCRIPTION
Please note that this pull request only solves the specific problem found in XTREM-243

A new pull request should be sent for switching all JRequest calls to JInput
