### PR TITLE
REDSHOP-2688 [Fix] Export Quotation - Get wrong user information.

### DIFF
--- a/component/admin/models/quotation.php
+++ b/component/admin/models/quotation.php
@@ -121,7 +121,7 @@ class RedshopModelQuotation extends RedshopModelList
 				)
 			)
 			->from($db->qn('#__redshop_quotation', 'q'))
-			->leftjoin($db->qn('#__redshop_users_info', 'uf') . ' ON q.user_id = uf.user_id AND uf.address_type = ' . $db->q('BT'))
+			->leftjoin($db->qn('#__redshop_users_info', 'uf') . ' ON q.user_info_id = uf.users_info_id AND uf.address_type = ' . $db->q('BT'))
 			->leftJoin($db->qn('#__redshop_quotation_item', 'qi') . ' ON qi.quotation_id = q.quotation_id');
 
 		if ($filter = $this->getState('filter'))


### PR DESCRIPTION
In Quotation mode, the user doesn't need to login and not user id.
When Export Quotation, it can't get right user information. 
How to test:
1. Do some quotation requests without login.
2. Go to Quotation manager in backend, then Export. 
3. Check user information on CSV exported file.
