### PR TITLE
REDSHOP-2690 PRISMIG-109 Removed utf8 encode in GLS export to improve Excel support

### DIFF
--- a/component/admin/models/order.php
+++ b/component/admin/models/order.php
@@ -308,6 +308,11 @@ class RedshopModelOrder extends RedshopModel
 
 				$row = array_merge($row, $userDetail);
 
+				for ($i = 0; $i < count($row); $i++)
+				{
+					$row[$i] = utf8_decode($row[$i]);
+				}
+
 				// Output CSV line
 				fputcsv($outputCsv, $row);
 			}
@@ -393,6 +398,11 @@ class RedshopModelOrder extends RedshopModel
 				);
 
 				$row = array_merge($row, $extraInfo, $rowAppend);
+
+				for ($i = 0; $i < count($row); $i++)
+				{
+					$row[$i] = utf8_decode($row[$i]);
+				}
 
 				// Output CSV line
 				fputcsv($outputCsv, $row);


### PR DESCRIPTION
I don't really like removing UTF-8 support but I'm also aware that most of our users use Excel for CSV read (which actually uses a UTF-16-like encoding).

This "fix" considers that for GLS exports
