### PR TITLE
REDSHOP-2725 Fix configuration tab default selected issue with browser storeage

### DIFF
--- a/component/admin/views/configuration/tmpl/default.php
+++ b/component/admin/views/configuration/tmpl/default.php
@@ -81,11 +81,9 @@ $url = $uri->root();
 <form action="<?php echo 'index.php?option=com_redshop'; ?>" method="post" name="adminForm" id="adminForm"
       enctype="multipart/form-data">
 	<?php
-	$dashboard = JFactory::getApplication()->input->getInt('dashboard');
+	$options = array('startOffset' => 0, 'useCookie' => true);
 
-	$options = array('startOffset' => 0);
-
-	if ($dashboard)
+	if (JFactory::getApplication()->input->getInt('dashboard'))
 	{
 		// Temporary fix - due to joomla bug have to force this code. Need to remove after fix in Joomla.
 		JFactory::getDocument()->addScriptDeclaration('


### PR DESCRIPTION
When selecting tab and save configuration. After saving all the time I changed to first tab. Instead of that after this fix it will be shown in last selected tab.
