### PR TITLE
Redshop 2725 - configuration tab default selected issue with browser storage

### DIFF
--- a/component/admin/controllers/configuration.php
+++ b/component/admin/controllers/configuration.php
@@ -29,7 +29,11 @@ class RedshopControllerConfiguration extends RedshopController
 	public function save($apply = 0)
 	{
 		$post = JRequest::get('post');
-
+		
+		$app = JFactory::getApplication();
+		$selectedTabPosition = $app->input->get('selectedTabPosition');
+		$app->setUserState('com_redshop.configuration.selectedTabPosition', $selectedTabPosition);
+		
 		for ($p = 0; $p < $post['tot_prod']; $p++)
 		{
 			if ($post['prodmng' . $p] != "")

--- a/component/admin/views/configuration/tmpl/default.php
+++ b/component/admin/views/configuration/tmpl/default.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
  * @package     RedSHOP.Backend
@@ -15,11 +16,26 @@ $url = $uri->root();
 ?>
 <script language="javascript" type="text/javascript">
 	Joomla.submitbutton = function (pressbutton) {
+		// Find the position of selected tab
+		var allTabsNames = document.querySelectorAll('dt.tabs a');
+		var selectedTabName  = document.querySelectorAll('dt.tabs.open a');
+		for (var i=0; i < allTabsNames.length; i++) {
+			if (selectedTabName[0].innerHTML === allTabsNames[i].innerHTML) {
+				var selectedTabPosition = i;
+				break;
+			}
+		}
+
 		var form = document.adminForm;
 		if (pressbutton) {
 			form.task.value = pressbutton;
 		}
 		if (pressbutton == 'save' || pressbutton == 'apply') {
+			if (pressbutton == 'save')
+				form.selectedTabPosition.value = 0;
+			else
+				form.selectedTabPosition.value = selectedTabPosition;
+
 			var obj = form.economic_integration;
 
 			var sel_discount_flag = false;
@@ -83,7 +99,7 @@ $url = $uri->root();
 	<?php
 	$dashboard = JFactory::getApplication()->input->getInt('dashboard');
 
-	$options = array('startOffset' => 0);
+	$options = array('startOffset' => $app->getUserState('com_redshop.configuration.selectedTabPosition'));
 
 	if ($dashboard)
 	{
@@ -104,11 +120,13 @@ $url = $uri->root();
 	}
 
 	echo JHtml::_('tabs.start', 'pane', $options);
+	$app->setUserState('com_redshop.configuration.selectedTabPosition', null);
 	$output = '';
 	echo JHtml::_('tabs.panel', JText::_('COM_REDSHOP_GENERAL_CONFIGURATION'), 'general');
 	?>
 	<input type="hidden" name="view" value="configuration"/>
 	<input type="hidden" name="task" value=""/>
+	<input type="hidden" name="selectedTabPosition" value=""/>
 	<?php
 	echo $this->loadTemplate('general');
 	echo JHtml::_('tabs.panel', JText::_('COM_REDSHOP_USER'), 'user');


### PR DESCRIPTION
When selecting tab and save configuration: /administrator/index.php?option=com_redshop&view=configuration.
After saving all the time it changed to first tab. Instead of that after this fix it will be shown in last selected tab.
