### PR TITLE
JMB-48 JMB-52 REDSHOP-2665 Fix sending wrong cvv2 number in paypal pro - creditcard payment

### DIFF
--- a/plugins/redshop_payment/rs_payment_paypalpro/rs_payment_paypalpro.php
+++ b/plugins/redshop_payment/rs_payment_paypalpro/rs_payment_paypalpro.php
@@ -54,7 +54,7 @@ class PlgRedshop_Paymentrs_Payment_Paypalpro extends JPlugin
 		$padDateMonth     = urlencode(str_pad($expDateMonth, 2, '0', STR_PAD_LEFT));
 
 		$expDateYear      = urlencode($ccdata['order_payment_expire_year']);
-		$cvv2Number       = urlencode($creditCardType);
+		$cvv2Number       = urlencode($ccdata['credit_card_code']);
 		$address1         = urlencode($data['billinginfo']->address);
 		$city             = urlencode($data['billinginfo']->city);
 		$state            = urlencode($data['billinginfo']->state_code);
@@ -104,17 +104,17 @@ class PlgRedshop_Paymentrs_Payment_Paypalpro extends JPlugin
 			$messageType            = 'Error';
 		}
 
+		// Set response message only for Error or Warning
 		if (1 == $this->params->get('debug_mode', 0)
 			&& ('Error' == $messageType || 'Warning' == $messageType))
 		{
 			$message = urldecode($httpParsedResponseAr["L_ERRORCODE0"] . ' <br>' . $httpParsedResponseAr["L_SHORTMESSAGE0"] . ' <br>' . $httpParsedResponseAr["L_LONGMESSAGE0"]);
+
+			JFactory::getApplication()->enqueueMessage($message, $messageType);
 		}
 
 		$values->transaction_id = $transaction_id;
 		$values->message        = $message;
-
-		// Set response message
-		JFactory::getApplication()->enqueueMessage($message, $messageType);
 
 		return $values;
 	}

--- a/plugins/redshop_payment/rs_payment_paypalpro/rs_payment_paypalpro.xml
+++ b/plugins/redshop_payment/rs_payment_paypalpro/rs_payment_paypalpro.xml
@@ -2,7 +2,7 @@
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment"
 		   method="upgrade">
 	<name>PLG_RS_PAYMENT_PAYPALPRO</name>
-	<version>1.5.0.8</version>
+	<version>1.5.0.9</version>
 	<redshop>1.5.0.6</redshop>
 	<creationDate>April 2013</creationDate>
 	<author>redCOMPONENT.com</author>

--- a/tests/acceptance/checkout/ProductsCheckoutBankTransfer2Cest.php
+++ b/tests/acceptance/checkout/ProductsCheckoutBankTransfer2Cest.php
@@ -104,6 +104,7 @@ class ProductsCheckoutBankTransfer2Cest
 		$I->seeElement($productFrontEndManagerPage->product($productName));
 		$I->click(['id' => "termscondition"]);
 		$I->click(['id' => "checkout_final"]);
+		$I->waitForText('Order Receipt', 60, ['class' => 'componentheading']);
 		$I->see('Order Receipt', "//div[@class='componentheading']");
 	}
 }


### PR DESCRIPTION
We were sending wrong cvv2 code and that is why we were having `successWithWarning` all the time. Fixed that issue in this PR.
