### PR TITLE
REDSHOP-2763 GLS not handling weight correctly in export

### DIFF
--- a/component/admin/models/order.php
+++ b/component/admin/models/order.php
@@ -262,8 +262,8 @@ class RedshopModelOrder extends RedshopModel
 
 				for ($c = 0, $cn = count($orderproducts); $c < $cn; $c++)
 				{
-					$weight      = $this->getProductWeight($orderproducts[$c]->product_id);
-					$totalWeight += ($weight * $orderproducts[$c]->product_quantity);
+					$weight      = (float) $this->getProductWeight($orderproducts[$c]->product_id);
+					$totalWeight += ($weight * (float)$orderproducts[$c]->product_quantity);
 				}
 
 				$parceltype = 'A';
@@ -360,8 +360,8 @@ class RedshopModelOrder extends RedshopModel
 
 				for ($c = 0, $cn = count($orderproducts); $c < $cn; $c++)
 				{
-					$weight      = $this->getProductWeight($orderproducts[$c]->product_id);
-					$totalWeight += ($weight * $orderproducts[$c]->product_quantity);
+					$weight      = (float) $this->getProductWeight($orderproducts[$c]->product_id);
+					$totalWeight += ($weight * (float) $orderproducts[$c]->product_quantity);
 				}
 
 				// Initialize row
@@ -452,13 +452,6 @@ class RedshopModelOrder extends RedshopModel
 	 */
 	public function getProductWeight($productId)
 	{
-		$db    = JFactory::getDbo();
-		$query = $db->getQuery(true)
-				->select('*')
-				->from($db->qn('#__redshop_product'))
-				->where($db->qn('product_id') . ' = ' . (int) $productId);
-		$db->setQuery($query);
-
-		return $db->loadResult();
+		return RedshopHelperProduct::getProductById($productId)->weight;
 	}
 }


### PR DESCRIPTION
#### Testing Info
- Place an order using GLS shipping gateway
- Make sure order is Confirmed which you have placed
- Select the orders in listing view backend and click on export gls button.
- Make sure you found correct weight of products which you have ordered
