### PR TITLE
REDSHOP-2764 Prevent e-conomic product updates, overwrite barcode number

### DIFF
--- a/plugins/economic/economic/economic.php
+++ b/plugins/economic/economic/economic.php
@@ -1168,14 +1168,14 @@ class plgEconomicEconomic extends JPlugin
 
 			if ($d['eco_prd_number'] != '')
 			{
-				$newProductNumber = $this->client->Product_UpdateFromData(array('data' => $prdinfo))->Product_UpdateFromDataResult;
+				$prdinfo['BarCode'] = $this->productGetBarCode($Handle);
+
+				return $this->client->Product_UpdateFromData(array('data' => $prdinfo))->Product_UpdateFromDataResult;
 			}
 			else
 			{
-				$newProductNumber = $this->client->Product_CreateFromData(array('data' => $prdinfo))->Product_CreateFromDataResult;
+				return $this->client->Product_CreateFromData(array('data' => $prdinfo))->Product_CreateFromDataResult;
 			}
-
-			return $newProductNumber;
 		}
 		catch (Exception $exception)
 		{
@@ -1184,6 +1184,36 @@ class plgEconomicEconomic extends JPlugin
 			if (DETAIL_ERROR_MESSAGE_ON)
 			{
 				JError::raiseWarning(21, "storeProduct:" . $exception->getMessage());
+			}
+			else
+			{
+				JError::raiseWarning(21, JText::_('DETAIL_ERROR_MESSAGE_LBL'));
+			}
+		}
+	}
+
+	/**
+	 * Get product barcode information from e-conomic product
+	 *
+	 * @param   object  $productHandle  Product Number Handle
+	 *
+	 * @return  string  Barcode
+	 */
+	protected function productGetBarCode($productHandle)
+	{
+		try
+		{
+			return $this->client->Product_GetBarCode(
+								array('productHandle' => $productHandle)
+							)->Product_GetBarCodeResult;
+		}
+		catch (Exception $e)
+		{
+			print("<p><i>ProductGetBarCode:" . $exception->getMessage() . "</i></p>");
+
+			if (DETAIL_ERROR_MESSAGE_ON)
+			{
+				JError::raiseWarning(21, "Product_GetBarCode:" . $exception->getMessage());
 			}
 			else
 			{


### PR DESCRIPTION
#### Testing Info
- Create e-conomic trial account
- Configure e-conomic plugin and enable integration from configuration
- Go to any product and save that product (no needs to change anything just save)
- Now, you will able to see that product in e-conomic
- Edit that product in e-conomic and add barcode 
- Save that product from redSHOP again and make sure that Barcode isn't removed from e-conomic product
