### PR TITLE
[tests] allow failures in checkout

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -270,8 +270,8 @@ class RoboFile extends \Robo\Tasks
 			->arg('--tap')
 			->arg('--fail-fast')
 			->arg('tests/acceptance/checkout/')
-			->run()
-			->stopOnFail();
+			->run();
+			// ->stopOnFail();
 
         $this->taskCodecept()
              ->arg('--steps')


### PR DESCRIPTION
This is a tests to avoid Checkout tests stopping the build when they fail. To avoid issues like https://github.com/redCOMPONENT-COM/redSHOP/pull/2230#issuecomment-180292336 were the failure is not related with the pull.
