### PR TITLE
REDSHOP-2829 redSHOP 1.6 is J3 compatible only

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -9,7 +9,7 @@ comp.name=redshop
 package.dir=
 
 # Joomla version to include in the package name, when using packager xml files
-joomla.version=j3_and_j25
+joomla.version=j3
 
 # Testing Joomla site at a localhost folder. Only needed when using build.xml
 www.dir=


### PR DESCRIPTION
This pull removes the j2.5 string from the generated packages

![screen shot 2016-03-14 at 13 19 52](https://cloud.githubusercontent.com/assets/1375475/13744351/7b509144-e9e7-11e5-8496-da2f70738a3a.png)
