### PR TITLE
REDSHOP-2663 Raise warning when send mail is disabled in Joomla configuration

### DIFF
--- a/component/admin/controllers/quotation_detail.php
+++ b/component/admin/controllers/quotation_detail.php
@@ -104,7 +104,7 @@ class RedshopControllerQuotation_detail extends RedshopController
 
 		if ($send == 1)
 		{
-			if ($model->sendQuotationMail($row->quotation_id))
+			if ($model->sendQuotationMail($row->quotation_id) && JFactory::getConfig()->get('mailonline') == 1)
 			{
 				$msg = JText::_('COM_REDSHOP_QUOTATION_DETAIL_SENT');
 			}


### PR DESCRIPTION
Fixed wrong warning message of quotation when "send mail" turned off 
https://redweb.atlassian.net/browse/REDSHOP-2663
