### PR TITLE
REDSHOP-2870 Add search filter for Stockimage - remove "0" value

### DIFF
--- a/component/admin/models/stockimage.php
+++ b/component/admin/models/stockimage.php
@@ -33,7 +33,7 @@ class RedshopModelStockimage extends RedshopModel
 
 		$limit = $app->getUserStateFromRequest($this->_context . 'limit', 'limit', $app->getCfg('list_limit'), 0);
 		$limitstart = $app->getUserStateFromRequest($this->_context . 'limitstart', 'limitstart', 0);
-		$filter = $app->getUserStateFromRequest($this->_context . 'filter', 'filter', 0);
+		$filter = $app->getUserStateFromRequest($this->_context . 'filter', 'filter', '');
 		$limitstart = ($limit != 0 ? (floor($limitstart / $limit) * $limit) : 0);
 		$this->setState('filter', $filter);
 		$this->setState('limit', $limit);


### PR DESCRIPTION
According to Javier last comment, remove value "0" appear inside search box on first time we access the view, instead the placeholder text should display
https://redweb.atlassian.net/browse/REDSHOP-2870
