### PR TITLE
REDSHOP-2800 Adding joomla advance fields in modules to avoide caching

### DIFF
--- a/modules/site/mod_redshop_cart/mod_redshop_cart.xml
+++ b/modules/site/mod_redshop_cart/mod_redshop_cart.xml
@@ -73,6 +73,46 @@
                        label="MOD_REDSHOP_CART_CART_BUTTON_TEXT_LBL"
                        description="MOD_REDSHOP_CART_CART_BUTTON_TEXT_DESC"/>
             </fieldset>
+            <fieldset name="advanced">
+              <field
+                name="layout"
+                type="modulelayout"
+                label="JFIELD_ALT_LAYOUT_LABEL"
+                description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
+
+              <field
+                name="moduleclass_sfx"
+                type="textarea"
+                rows="3"
+                label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
+                description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
+
+              <field
+                name="cache"
+                type="list"
+                default="0"
+                label="COM_MODULES_FIELD_CACHING_LABEL"
+                description="COM_MODULES_FIELD_CACHING_DESC"
+              >
+                <option value="1">JGLOBAL_USE_GLOBAL</option>
+                <option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
+              </field>
+
+              <field
+                name="cache_time"
+                type="text"
+                default="900"
+                label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
+                description="COM_MODULES_FIELD_CACHE_TIME_DESC" />
+
+              <field
+                name="cachemode"
+                type="hidden"
+                default="static">
+                <option
+                  value="static"></option>
+              </field>
+          </fieldset>
         </fields>
     </config>
 </extension>


### PR DESCRIPTION
Now caching can be disable using advance tab.
By Default **Cache is disabled**

![no-caching](https://cloud.githubusercontent.com/assets/2002921/14663521/5fde72c2-06df-11e6-87d6-50bca74fb642.png)
