### PR TITLE
REDSHOP-2904 New method to get all products

### DIFF
--- a/component/admin/models/mass_discount_detail.php
+++ b/component/admin/models/mass_discount_detail.php
@@ -8,8 +8,8 @@
  */
 
 defined('_JEXEC') or die;
-JLoader::load('RedshopHelperProduct');
 
+JLoader::load('RedshopHelperProduct');
 
 class RedshopModelMass_discount_detail extends RedshopModel
 {
@@ -521,14 +521,6 @@ class RedshopModelMass_discount_detail extends RedshopModel
 				. 'product WHERE published = 1 and product_id =""';
 		}
 
-		$this->_db->setQuery($query);
-
-		return $this->_db->loadObjectList();
-	}
-
-	public function GetProductList()
-	{
-		$query = 'SELECT product_name as text,product_id as value FROM ' . $this->_table_prefix . 'product WHERE published = 1';
 		$this->_db->setQuery($query);
 
 		return $this->_db->loadObjectList();

--- a/component/admin/views/mass_discount_detail/view.html.php
+++ b/component/admin/views/mass_discount_detail/view.html.php
@@ -51,8 +51,6 @@ class RedshopViewMass_discount_detail extends RedshopView
 
 		$manufacturers = $model->getmanufacturers();
 
-		$productData = $model->GetProductList();
-
 		$category_id = explode(',', $detail->category_id);
 		$tmp = new stdClass;
 		$tmp = @array_merge($tmp, $category_id);

--- a/libraries/redshop/product/product.php
+++ b/libraries/redshop/product/product.php
@@ -18,9 +18,26 @@ defined('_JEXEC') or die;
  */
 class RedshopProduct
 {
-	protected $info = null;
+	/**
+	 * Static instance of product Object
+	 *
+	 * @var  array of object
+	 */
+	private static $objInstance = [];
 
-	public function __construct($id)
+	/**
+	 * Product Information
+	 *
+	 * @var  null
+	 */
+	protected $info;
+
+	/**
+	 * Protected product constructor. Must use getInstance() method.
+	 *
+	 * @param  integer  $id  Product Id
+	 */
+	protected function __construct($id)
 	{
 		if (!is_int($id))
 		{
@@ -38,18 +55,90 @@ class RedshopProduct
 		}
 	}
 
-	public function getId()
+	/**
+	 * Returns product instance
+	 *
+	 * @return  object  product Object
+	 */
+	public static function getInstance($id)
+	{
+		if (!array_key_exists($id, self::$objInstance))
+		{
+			self::$objInstance[$id] = new RedshopProduct($id);
+		}
+
+		return self::$objInstance[$id];
+	}
+
+	/**
+	 * Set variables in info
+	 *
+	 * @param  string  $name   Name of information property
+	 * @param  mixed   $value  Value of property
+	 */
+	public function __set($name, $value)
+	{
+		$this->info->$name = $value;
+	}
+
+	/**
+	 * Get product info property
+	 *
+	 * @param   string  $name  Name of property
+	 *
+	 * @return  mixed         value of property
+	 */
+	public function __get($name)
+	{
+		if (isset($this->info->$name))
+		{
+			return $this->info->$name;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check for property exists
+	 *
+	 * @param   string   $name  Property name
+	 *
+	 * @return  boolean  True if property found
+	 */
+	public function __isset($name)
+	{
+		return property_exists($this->info, $name);
+	}
+
+	/**
+	 * Current product id
+	 *
+	 * @return  integer  Product Id
+	 */
+	public function id()
 	{
 		return (int) $this->info->product_id;
 	}
 
-	public function getName()
+	/**
+	 * Get product name
+	 *
+	 * @return  string  Product Name
+	 */
+	public function name()
 	{
 		return $this->info->product_name;
 	}
 
-	public function getPrice()
+	/**
+	 * Product Price
+	 *
+	 * @todo    Don't use - Under Development
+	 *
+	 * @return  float  Product final price
+	 */
+	public function price()
 	{
-		JLog::add('Don\'t use this function, still under developement.');
+		JLog::add('Don\'t use price() function from ' . __CLASS__ . ', still under developement.');
 	}
 }

--- a/libraries/redshop/redshop.php
+++ b/libraries/redshop/redshop.php
@@ -87,4 +87,14 @@ abstract class Redshop
 	{
 		return (string) static::getManifest()->version;
 	}
+
+	/**
+	 * Gets product object
+	 *
+	 * @return  RedshopProduct object
+	 */
+	public static function product($id)
+	{
+		return RedshopProduct::getInstance($id);
+	}
 }


### PR DESCRIPTION
- Removed unnecessary `GetProductList` method from mass discount
- `getList` method to get all the products from DB

``` php
$allProducts = RedshopHelperProduct::getList();
```
- Advanced approach to get product object

``` php
$product = Redshop::product($id);

$productName = $product->name();

$productDescription = $product->product_desc;
```
- [x] Once this PR merge add above info into wiki.
