### PR TITLE
REDSHOP-2531 Prepare payment_express plugin for relese

### DIFF
--- a/plugins/redshop_payment/rs_payment_payment_express/rs_payment_payment_express.xml
+++ b/plugins/redshop_payment/rs_payment_payment_express/rs_payment_payment_express.xml
@@ -2,9 +2,9 @@
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment"
            method="upgrade">
     <name>PLG_RS_PAYMENT_PAYMENT_EXPRESS</name>
-    <version>1.5.0.6</version>
+    <version>1.5.0.6.1</version>
     <redshop>1.5.0.6</redshop>
-    <creationDate>April 2013</creationDate>
+    <creationDate>May 2016</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>
     <authorUrl>http://www.redcomponent.com</authorUrl>


### PR DESCRIPTION
Updates #2359 adding forgotten bump of plugin version:

![screen shot 2016-05-05 at 11 35 17](https://cloud.githubusercontent.com/assets/1375475/15040513/b954a024-12b5-11e6-98bc-e92d96a02da2.png)
