### PR TITLE
REDSHOP-2969 Payment process fail when the checkbox "Require CVD number for credit card transactions" in admin page of Beanstream is checked

### DIFF
--- a/plugins/redshop_payment/rs_payment_beanstream/rs_payment_beanstream.php
+++ b/plugins/redshop_payment/rs_payment_beanstream/rs_payment_beanstream.php
@@ -63,6 +63,7 @@ class plgRedshop_paymentrs_payment_beanstream extends JPlugin
 			'trnCardNumber'   => $ccdata['order_payment_number'],
 			'trnExpMonth'     => $ccdata['order_payment_expire_month'],
 			'trnExpYear'      => $order_payment_expire_year,
+			'trnCardCvd'      => $ccdata['credit_card_code'],
 			'trnOrderNumber'  => $data['order_number'],
 			'trnAmount'       => $order_total,
 			'ordEmailAddress' => $data['billinginfo']->user_email,

--- a/plugins/redshop_payment/rs_payment_beanstream/rs_payment_beanstream.xml
+++ b/plugins/redshop_payment/rs_payment_beanstream/rs_payment_beanstream.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="2.5.0" client="site" type="plugin" group="redshop_payment" method="upgrade">
     <name>PLG_RS_PAYMENT_BEANSTREAM</name>
-    <version>1.5.0.6</version>
+    <version>1.5.0.6.1</version>
     <redshop>1.5.0.6</redshop>
-    <creationDate>April 2013</creationDate>
+    <creationDate>June 2016</creationDate>
     <author>redCOMPONENT.com</author>
     <authorEmail>email@redcomponent.com</authorEmail>
     <authorUrl>http://www.redcomponent.com</authorUrl>


### PR DESCRIPTION
https://redweb.atlassian.net/browse/REDSHOP-2969
