### PR TITLE
REDSHOP-2995 Paypal Credit Card Payment: Negative vat issue

### DIFF
--- a/plugins/redshop_payment/paypalcreditcard/paypalcreditcard.php
+++ b/plugins/redshop_payment/paypalcreditcard/paypalcreditcard.php
@@ -125,25 +125,25 @@ class plgRedshop_PaymentPaypalCreditcard extends RedshopPaypalPayment
 		{
 			$cartItem    = $cart[$i];
 			$product     = RedshopHelperProduct::getProductById($cartItem['product_id']);
+			$tax         = ($cartItem['product_vat'] < 0) ? 0 : $cartItem['product_vat'];
 			$item        = new Item();
 			$cartItems[] =  $item->setName($product->product_name)
 								->setDescription($product->product_s_desc)
 								->setCurrency(CURRENCY_CODE)
 								->setQuantity($cartItem['quantity'])
-								->setTax($cartItem['product_vat'])
+								->setTax($tax)
 								->setPrice($cartItem['product_price']);
 		}
 
 		$itemList = new ItemList();
 		$itemList->setItems($cartItems);
 
+		$cartTax = ($cart['tax'] < 0) ? 0 : $cart['tax'];
+
 		// Additional payment details
-		// Use this optional field to set additional
-		// payment information such as tax, shipping
-		// charges etc.
 		$details = new Details();
 		$details->setShipping($cart['shipping'])
-				->setTax($cart['tax'])
+				->setTax($cartTax)
 				->setSubtotal($cart['subtotal']);
 
 		// Amount
@@ -699,22 +699,28 @@ class plgRedshop_PaymentPaypalCreditcard extends RedshopPaypalPayment
 		for ($i = 0, $n = count($orderItems); $i < $n; $i++)
 		{
 			$orderItem   = $orderItems[$i];
+
+			$tax = ($orderItem->product_item_price - $orderItem->product_item_price_excl_vat);
+			$tax = ($tax < 0) ? 0 : $tax;
+
 			$item        = new Item;
 			$cartItems[] =  $item->setName($orderItem->order_item_name)
 								->setDescription('')
 								->setCurrency(CURRENCY_CODE)
 								->setQuantity($orderItem->product_quantity)
-								->setTax($orderItem->product_item_price - $orderItem->product_item_price_excl_vat)
+								->setTax()
 								->setPrice($orderItem->product_item_price);
 		}
 
 		$itemList = new ItemList;
 		$itemList->setItems($cartItems);
 
+		$orderTax = ($orderInfo->order_tax < 0) ? 0 : $orderInfo->order_tax;
+
 		// Additional payment details
 		$details = new Details;
 		$details->setShipping($orderInfo->order_shipping)
-				->setTax($orderInfo->order_tax)
+				->setTax($orderTax)
 				->setSubtotal($orderInfo->order_subtotal);
 
 		// Amount


### PR DESCRIPTION
**I am not able to reproduce the issue but this is what I got from customer.**

```
showing negative number when adding shipping, once refreshed its fine.  This is what it shows.

Placed Order #1703 on DEV Front End.

Added Shipping on DEV Admin Side.

Without Refreshing after shipping added -$10.00 this message came up.

Error

Paypal Credit card payment fail. 
Got Http response code 400 when accessing https://api.paypal.com/v1/payments/payment.VALIDATION_ERROR
transactions[0].amount.details.tax: Currency amount must be non-negative number, may optionally contain exactly 2 decimal places separated by '.', optional thousands separator ',', limited to 7 digits before the decimal point
transactions[0].item_list.items[2].tax: Currency amount must be non-negative number, may optionally contain exactly 2 decimal places separated by '.', optional thousands separator ',', limited to 7 digits before the decimal point
Invalid request - see details https://developer.paypal.com/webapps/developer/docs/api/#VALIDATION_ERROR
```

So, I have fixed based on that to make sure I don't pass negative value.
