### PR TITLE
REDSHOP-2218 Allow related products template to include custom field tags

### DIFF
--- a/component/site/helpers/producthelper.php
+++ b/component/site/helpers/producthelper.php
@@ -10208,8 +10208,10 @@ class producthelper
 					$related_template_data = $this->getProductOnSaleComment($related_product[$r], $related_template_data);
 					$related_template_data = $this->getSpecialProductComment($related_product[$r], $related_template_data);
 					
+					$isCategorypage = (JFactory::getApplication()->input->get('view') == "category") ? 1 : 0;
+					
 					//  Extra field display
- +					$related_template_data = $this->getExtraSectionTag($extraFieldName, $related_product[$r]->product_id, "1", $related_template_data, 1);
+ +					$related_template_data = $this->getExtraSectionTag($extraFieldName, $related_product[$r]->product_id, "1", $related_template_data, $isCategorypage);
 
 					// Related product attribute price list
 					$related_template_data = $this->replaceAttributePriceList($related_product[$r]->product_id, $related_template_data);


### PR DESCRIPTION
Fix problem reported by Oscar (his last comment in task): "custom field is replaced in product template but not in related_products template"
https://redweb.atlassian.net/browse/REDSHOP-2218
