### PR TITLE
REDSHOP-3173 Update get order_status

### DIFF
--- a/component/admin/helpers/order_functions.php
+++ b/component/admin/helpers/order_functions.php
@@ -670,7 +670,7 @@ class order_functions
 		$stockroomhelper = rsstockroomhelper::getInstance();
 
 		$newStatus       = $app->input->getCmd('status');
-		$paymentStatus   = $app->input->getCmd('order_paymentstatus');
+		$paymentStatus   = $app->input->getString('order_paymentstatus');
 		$return          = $app->input->getCmd('return');
 
 		$customerNote    = $app->input->get('customer_note', array(), 'array');


### PR DESCRIPTION
Issue caused because we are using space in order status: "Partial Paid" .
Use getCmd will return PartialPaid and no value in select for this.
