### PR TITLE
REDSHOP-3263 Remove hide class for input field name

### DIFF
--- a/component/admin/views/fields_detail/tmpl/default.php
+++ b/component/admin/views/fields_detail/tmpl/default.php
@@ -358,7 +358,7 @@ $url = $uri->root();
 
 								<input
 									type="text"
-									class="divfieldText hide"
+									class="divfieldText"
 									name="extra_name[]"
 									value="<?php echo htmlentities($this->lists['extra_data'][$k]->field_name);?>"
 								/>


### PR DESCRIPTION
This hide class caused input field name is hidden, and we can't change field name as expected
