### PR TITLE
REDSHOP-3302 Remove required field

### DIFF
--- a/component/site/views/product/tmpl/default.xml
+++ b/component/site/views/product/tmpl/default.xml
@@ -11,7 +11,6 @@
 
             <field name="pid" type="products"
                    label="COM_REDSHOP_SELECT_PRODUCTS"
-                   required="true"
                    description="COM_REDSHOP_A_PRODUCT"
                     />
         </fieldset>


### PR DESCRIPTION
By default we already use pid = 0;
AFTER SAVED we'll update this field.

I assume pid is not required as "forcing" so i remove required. !
