### PR TITLE
REDSHOP-3426: GIFTCARD: Table '#__#__redshop_giftcard' doesn't exist SQL=SHOW FULL COLUMNS FROM `#__#__redshop_giftcard`

### DIFF
--- a/component/admin/tables/giftcard.php
+++ b/component/admin/tables/giftcard.php
@@ -23,7 +23,7 @@ class RedshopTableGiftcard extends RedshopTable
 	 *
 	 * @var  string
 	 */
-	protected $_tableName = '#__redshop_giftcard';
+	protected $_tableName = 'redshop_giftcard';
 
 	/**
 	 * The table key column. Usually: id


### PR DESCRIPTION
GIFTCARD: Table 'j35.yo509_yo509_redshop_giftcard' doesn't exist SQL=SHOW FULL COLUMNS FROM `yo509_yo509_redshop_giftcard`
