### PR TITLE
ONKELP-166 Change default image quality configuration to 70

### DIFF
--- a/component/admin/config/config.dist.php
+++ b/component/admin/config/config.dist.php
@@ -331,7 +331,7 @@ class RedshopConfig {
 	public $POSTDANMARK_POSTALCODE = '123456';
 	public $MENUHIDE = '';
 	public $AJAX_CART_DISPLAY_TIME = '3000';
-	public $IMAGE_QUALITY_OUTPUT = '100';
+	public $IMAGE_QUALITY_OUTPUT = '70';
 	public $SEND_CATALOG_REMINDER_MAIL = '0';
 	public $CATEGORY_IN_SEF_URL = '0';
 	public $USE_BLANK_AS_INFINITE = '0';


### PR DESCRIPTION
There seems to be something wrong with redSHOP's way of scaling images up. If you look at the thumbnails generated, they usually take up 100 kb more than the original file.
The original file has the resolution of 270 x 460 pixels, and the size of 15.1 kb.
The scaled up thumbnail image has a resolution of 393 x 670 pixels, and a size of 113 kb.

Solution: change default scaling to 70%