### PR TITLE
REDSHOP-3670 Only execute migrate for version lower than 1.6

### DIFF
--- a/install.php
+++ b/install.php
@@ -169,25 +169,9 @@ class Com_RedshopInstallerScript
 	 */
 	public function getOldParam($name)
 	{
-		if (is_null(self::$oldManifest))
-		{
-			$db = JFactory::getDbo();
-			$query = $db->getQuery(true)
-				->select('manifest_cache')
-				->from($db->qn('#__extensions'))
-				->where('type = ' . $db->q('component'))
-				->where('element = ' . $db->q('com_redshop'));
-			self::$oldManifest = json_decode($db->setQuery($query)->loadResult(), true);
-		}
+		require_once __DIR__ . '/libraries/redshop/helper/joomla.php';
 
-		if (isset(self::$oldManifest[$name]))
-		{
-			return self::$oldManifest[$name];
-		}
-		else
-		{
-			return null;
-		}
+		return RedshopHelperJoomla::getManifestValue($name);
 	}
 
 	/**

--- a/libraries/redshop/helper/config.php
+++ b/libraries/redshop/helper/config.php
@@ -304,7 +304,7 @@ class RedshopHelperConfig
 	protected function loadOldConfig()
 	{
 		// Since 1.6 we started moving to new config than try to migrate it
-		if (version_compare($this->getOldParam('version'), '1.6', '<'))
+		if (version_compare(RedshopHelperJoomla::getManifestValue('version'), '1.6', '<'))
 		{
 			JFactory::getApplication()->enqueueMessage(JText::_('COM_REDSHOP_TRY_TO_MIGRATE_PREVIOUS_CONFIGURATION'), 'notice');
 			$oldConfigFile = JPATH_ADMINISTRATOR . '/components/com_redshop/helpers/redshop.cfg.php';

--- a/libraries/redshop/helper/config.php
+++ b/libraries/redshop/helper/config.php
@@ -349,7 +349,7 @@ class RedshopHelperConfig
 			return false;
 		}
 
-		return true;
+		return false;
 	}
 
 	/**

--- a/libraries/redshop/helper/joomla.php
+++ b/libraries/redshop/helper/joomla.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package     RedSHOP.Frontend
+ * @subpackage  Helper
+ *
+ * @copyright   Copyright (C) 2008 - 2016 redCOMPONENT.com. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Joomla! helper
+ *
+ * @since  2.0.0.6
+ */
+class RedshopHelperJoomla
+{
+
+	/**
+	 * Get redSHOP manifest value
+	 *
+	 * @param   string  $name     Name param
+	 * @param   mixed   $default  Default return value if value is not exists
+	 *
+	 * @return  mixed
+	 */
+	public static function getManifestValue($name, $default = null)
+	{
+		static $oldManifest;
+
+		if (!isset($oldManifest))
+		{
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('manifest_cache')
+				->from($db->qn('#__extensions'))
+				->where('type = ' . $db->q('component'))
+				->where('element = ' . $db->q('com_redshop'));
+			$oldManifest = json_decode($db->setQuery($query)->loadResult(), true);
+		}
+
+		if (isset($oldManifest[$name]))
+		{
+			return $oldManifest[$name];
+		}
+		else
+		{
+			return $default;
+		}
+	}
+}


### PR DESCRIPTION
In this PR
- Move execute code to get manifest param into helper. Inside getOldParam will call this helper function. In fact i would expect install.php only have installation code, not relative . That's why i moved above code to helper.
- Inside loadOldConfig i have checked if current installed version lower than 1.6 than we'll execute migrating. If not do nothing. Because since version 1.6 we already changed config code ? Isn't it ?.

I keep notice message because it should be there to know all migrate process and result.