### PR TITLE
REDSHOP-3952 [Fix] Fatal error of RedshopHelperWorld

### DIFF
--- a/libraries/redshop/helper/world.php
+++ b/libraries/redshop/helper/world.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
  *
  * @since  1.6.1
  */
-abstract class RedshopHelperWorld
+class RedshopHelperWorld
 {
 	/**
 	 * Static instance of class
@@ -49,7 +49,7 @@ abstract class RedshopHelperWorld
 	{
 		if (self::$instance === null)
 		{
-			self::$instance = new static;
+			self::$instance = new self;
 		}
 
 		return self::$instance;


### PR DESCRIPTION
 Fatal error: Cannot instantiate abstract class RedshopHelperWorld in /opt/lampp/htdocs/j36/libraries/redshop/helper/world.php on line 52

- Remove abstract in class because not need.