### PR TITLE
REDSHOP-3697 Fix show small information for Media - Document type

### DIFF
--- a/component/admin/views/media_detail/tmpl/default.php
+++ b/component/admin/views/media_detail/tmpl/default.php
@@ -195,7 +195,6 @@ if ($showbuttons)
 
 						        if ($this->detail->media_name)
 						        {
-
 							        $filetype = strtolower(JFile::getExt($this->detail->media_name));
 
 							        if ($filetype == 'png' || $filetype == 'jpg' || $filetype == 'jpeg' || $filetype == 'gif')
@@ -210,13 +209,19 @@ if ($showbuttons)
 									        Redshop::getConfig()->get('USE_IMAGE_SIZE_SWAPPING')
 								        );
 								        ?>
-                                        <a class="joom-box btn btn-primary"
-                                           href="<?php echo $url . 'components/com_redshop/assets/' . $this->detail->media_type . '/' . $this->detail->media_section . '/' . $this->detail->media_name; ?>"
-                                           title="<?php echo JText::_('COM_REDSHOP_VIEW_IMAGE'); ?>"
-                                           rel="{handler: 'image', size: {}}">
-                                            <img
-                                                    src="<?php echo $thumbUrl; ?>"
-                                                    alt="image"/></a>
+								        <?php if ($thumbUrl): ?>
+                                            <a class="joom-box btn btn-primary"
+                                               href="<?php echo $url . 'components/com_redshop/assets/' . $this->detail->media_type . '/' . $this->detail->media_section . '/' . $this->detail->media_name; ?>"
+                                               title="<?php echo JText::_('COM_REDSHOP_VIEW_IMAGE'); ?>"
+                                               rel="{handler: 'image', size: {}}">
+                                                <img
+                                                        src="<?php echo $thumbUrl; ?>"
+                                                        alt="image"/>
+                                            </a>
+							            <?php else: ?>
+                                            <small><?php echo $this->detail->media_name; ?></small>
+                                            <input type="hidden" name="file[]" id="file" value="<?php echo $this->detail->media_name;?>">
+							            <?php endif; ?>
 								        <?php
 							        }
 						        }

--- a/libraries/redshop/helper/media.php
+++ b/libraries/redshop/helper/media.php
@@ -246,8 +246,15 @@ class RedshopHelperMedia
 		}
 
 		$filePath     = JPATH_SITE . '/components/com_redshop/assets/images/' . $type . '/' . $imageName;
-		$physiclePath = self::generateImages($filePath, $dest, $width, $height, $command, $proportional);
-		$thumbUrl     = REDSHOP_FRONT_IMAGES_ABSPATH . $type . '/thumb/' . basename($physiclePath);
+		$physicalPath = self::generateImages($filePath, $dest, $width, $height, $command, $proportional);
+
+		// Can not generate image
+		if (!$physicalPath)
+		{
+			return false;
+		}
+
+		$thumbUrl     = REDSHOP_FRONT_IMAGES_ABSPATH . $type . '/thumb/' . basename($physicalPath);
 
 		return $thumbUrl;
 	}


### PR DESCRIPTION
… type

This issue caused by mixing reason
- As type "Document" it can be any file type: Image or Zip or Binary.
By this way, we can't render as well. But we still need some text to inform that file was uploaded before. This PR used for this case.

- File upload still is limited by Joomla! ( or redSHOP ) file extension allowed.
If we are not allowed for .dat and upload .dat file will cause the error. This PR is not fixing that issue.

Besides that, I also fixed for media helper.
By any reason we can't generate image it should be returned with False value instead "invalid" URL.

cc @thongredweb 