### PR TITLE
REDSHOP-3928 Do not allow manual input datetime with calendar form field

### DIFF
--- a/component/admin/models/forms/mass_discount.xml
+++ b/component/admin/models/forms/mass_discount.xml
@@ -43,6 +43,7 @@
                 description="COM_REDSHOP_MASS_DISCOUNT_START_DATE_DESC"
                 class="form-control"
                 default=""
+                readonly="true"
                 />
         <field
                 name="end_date"
@@ -51,6 +52,7 @@
                 description="COM_REDSHOP_MASS_DISCOUNT_END_DATE_DESC"
                 class="form-control"
                 default=""
+                readonly="true"
                 />
         <field
                 name="discount_product"

--- a/component/admin/models/forms/mass_discount.xml
+++ b/component/admin/models/forms/mass_discount.xml
@@ -38,7 +38,7 @@
                 />
         <field
                 name="start_date"
-                type="calendar"
+                type="redshop.calendar"
                 label="COM_REDSHOP_MASS_DISCOUNT_START_DATE"
                 description="COM_REDSHOP_MASS_DISCOUNT_START_DATE_DESC"
                 class="form-control"
@@ -47,7 +47,7 @@
                 />
         <field
                 name="end_date"
-                type="calendar"
+                type="redshop.calendar"
                 label="COM_REDSHOP_MASS_DISCOUNT_END_DATE"
                 description="COM_REDSHOP_MASS_DISCOUNT_END_DATE_DESC"
                 class="form-control"

--- a/libraries/redshop/form/field/calendar.php
+++ b/libraries/redshop/form/field/calendar.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * @package     RedSHOP.Library
+ * @subpackage  Form.Field
+ *
+ * @copyright   Copyright (C) 2008 - 2016 redCOMPONENT.com. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+require_once JPATH_LIBRARIES . '/redshop/library.php';
+
+/**
+ * Calendar field override
+ *
+ * @since  1.0
+ */
+class RedshopFormFieldCalendar extends JFormField
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $type = 'Calendar';
+
+	/**
+	 * The allowable maxlength of calendar field.
+	 *
+	 * @var    integer
+	 * @since  3.2
+	 */
+	protected $maxlength;
+
+	/**
+	 * The format of date and time.
+	 *
+	 * @var    integer
+	 * @since  3.2
+	 */
+	protected $format;
+
+	/**
+	 * The filter.
+	 *
+	 * @var    integer
+	 * @since  3.2
+	 */
+	protected $filter;
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to the the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   3.2
+	 */
+	public function __get($name)
+	{
+		switch ($name)
+		{
+			case 'maxlength':
+			case 'format':
+			case 'filter':
+				return $this->$name;
+		}
+
+		return parent::__get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to the the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function __set($name, $value)
+	{
+		switch ($name)
+		{
+			case 'maxlength':
+				$value = (int) $value;
+			case 'format':
+			case 'filter':
+				$this->$name = (string) $value;
+				break;
+
+			default:
+				parent::__set($name, $value);
+		}
+	}
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   3.2
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		$return = parent::setup($element, $value, $group);
+
+		if ($return)
+		{
+			$this->maxlength = (int) $this->element['maxlength'] ? (int) $this->element['maxlength'] : 45;
+			$this->format    = (string) $this->element['format'] ? (string) $this->element['format'] : '%Y-%m-%d';
+			$this->filter    = (string) $this->element['filter'] ? (string) $this->element['filter'] : 'USER_UTC';
+		}
+
+		return $return;
+	}
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @return  string  The field input markup.
+	 *
+	 * @since   11.1
+	 */
+	protected function getInput()
+	{
+		// Translate placeholder text
+		$hint = $this->translateHint ? JText::_($this->hint) : $this->hint;
+
+		// Initialize some field attributes.
+		$format = $this->format;
+
+		// Build the attributes array.
+		$attributes = array();
+
+		empty($this->size)      ? null : $attributes['size'] = $this->size;
+		empty($this->maxlength) ? null : $attributes['maxlength'] = $this->maxlength;
+		empty($this->class)     ? null : $attributes['class'] = $this->class;
+		!$this->readonly        ? null : $attributes['readonly'] = 'readonly';
+		!$this->disabled        ? null : $attributes['disabled'] = 'disabled';
+		empty($this->onchange)  ? null : $attributes['onchange'] = $this->onchange;
+		!strlen($hint)          ? null : $attributes['placeholder'] = $hint;
+		$this->autocomplete     ? null : $attributes['autocomplete'] = 'off';
+		!$this->autofocus       ? null : $attributes['autofocus'] = '';
+
+		if ($this->required)
+		{
+			$attributes['required'] = '';
+			$attributes['aria-required'] = 'true';
+		}
+
+		// Handle the special case for "now".
+		if (strtoupper($this->value) == 'NOW')
+		{
+			$this->value = JFactory::getDate()->format('Y-m-d H:i:s');
+		}
+
+		// Get some system objects.
+		$config = JFactory::getConfig();
+		$user = JFactory::getUser();
+
+		// If a known filter is given use it.
+		switch (strtoupper($this->filter))
+		{
+			case 'SERVER_UTC':
+				// Convert a date to UTC based on the server timezone.
+				if ($this->value && $this->value != JFactory::getDbo()->getNullDate())
+				{
+					// Get a date object based on the correct timezone.
+					$date = JFactory::getDate($this->value, 'UTC');
+					$date->setTimezone(new DateTimeZone($config->get('offset')));
+
+					// Transform the date string.
+					$this->value = $date->format('Y-m-d H:i:s', true, false);
+				}
+
+				break;
+
+			case 'USER_UTC':
+				// Convert a date to UTC based on the user timezone.
+				if ($this->value && $this->value != JFactory::getDbo()->getNullDate())
+				{
+					// Get a date object based on the correct timezone.
+					$date = JFactory::getDate($this->value, 'UTC');
+
+					$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
+
+					// Transform the date string.
+					$this->value = $date->format('Y-m-d H:i:s', true, false);
+				}
+
+				break;
+		}
+
+		// Including fallback code for HTML5 non supported browsers.
+		JHtml::_('jquery.framework');
+		JHtml::_('script', 'system/html5fallback.js', false, true);
+
+		return JHtml::_('redshopcalendar.calendar', $this->value, $this->name, $this->id, $format, $attributes);
+	}
+}

--- a/libraries/redshop/html/redshopcalendar.php
+++ b/libraries/redshop/html/redshopcalendar.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @package     RedSHOP.Library
+ * @subpackage  HTML
+ *
+ * @copyright   Copyright (C) 2008 - 2016 redCOMPONENT.com. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Utilities\ArrayHelper;
+
+/**
+ * Utility class for creating HTML Calendar
+ *
+ * @package     RedSHOP.Library
+ * @subpackage  HTML
+ * @since       1.5
+ */
+abstract class JHtmlRedshopcalendar
+{
+	/**
+	 * Displays a calendar control field
+	 *
+	 * @param   string  $value    The date value
+	 * @param   string  $name     The name of the text field
+	 * @param   string  $id       The id of the text field
+	 * @param   string  $format   The date format
+	 * @param   mixed   $attribs  Additional HTML attributes
+	 *
+	 * @return  string  HTML markup for a calendar field
+	 *
+	 * @since   1.5
+	 */
+	public static function calendar($value, $name, $id, $format = '%Y-%m-%d', $attribs = null)
+	{
+		static $done;
+
+		if ($done === null)
+		{
+			$done = array();
+		}
+
+		$readonly = isset($attribs['readonly']) && $attribs['readonly'] == 'readonly';
+		$disabled = isset($attribs['disabled']) && $attribs['disabled'] == 'disabled';
+
+		if (is_array($attribs))
+		{
+			$attribs['class'] = isset($attribs['class']) ? $attribs['class'] : 'input-medium';
+			$attribs['class'] = trim($attribs['class'] . ' hasTooltip');
+
+			$attribs = ArrayHelper::toString($attribs);
+		}
+
+		JHtml::_('bootstrap.tooltip');
+
+		// Format value when not nulldate ('0000-00-00 00:00:00'), otherwise blank it as it would result in 1970-01-01.
+		if ($value && $value != JFactory::getDbo()->getNullDate() && strtotime($value) !== false)
+		{
+			$tz = date_default_timezone_get();
+			date_default_timezone_set('UTC');
+			$inputvalue = strftime($format, strtotime($value));
+			date_default_timezone_set($tz);
+		}
+		else
+		{
+			$inputvalue = '';
+		}
+
+		// Load the calendar behavior
+		JHtml::_('behavior.calendar');
+
+		// Only display the triggers once for each control.
+		if (!in_array($id, $done))
+		{
+			$document = JFactory::getDocument();
+			$document
+				->addScriptDeclaration(
+					'jQuery(document).ready(function($) {Calendar.setup({
+			// Id of the input field
+			inputField: "' . $id . '",
+			// Format of the input field
+			ifFormat: "' . $format . '",
+			// Trigger for the calendar (button ID)
+			button: "' . $id . '_img",
+			// Alignment (defaults to "Bl")
+			align: "Tl",
+			singleClick: true,
+			firstDay: ' . JFactory::getLanguage()->getFirstDay() . '
+			});});'
+				);
+			$done[] = $id;
+		}
+
+		// Hide button using inline styles for readonly/disabled fields
+		$btn_style = ' style=""';
+		$div_class = ' class="input-append"';
+
+		return '<div' . $div_class . '>'
+			. '<input type="text" title="' . ($inputvalue ? JHtml::_('date', $value, null, null) : '')
+			. '" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
+			. '<button type="button" class="btn" id="' . $id . '_img"' . $btn_style . '><span class="icon-calendar"></span></button>'
+			. '</div>';
+	}
+}


### PR DESCRIPTION
…r form field

This PR i have created new custom form field calendar and JHtml.
In this override will render calendar with input readonly ( if enabled ) but show up calendar button.

By this way, user can not manual input calendar with readonly. So they can't abuse value