### PR TITLE
[Optimize] Add function for Order Entity

### DIFF
--- a/component/admin/models/install.php
+++ b/component/admin/models/install.php
@@ -60,7 +60,7 @@ class RedshopModelInstall extends RedshopModelList
 
 		$tasks = array(
 			array(
-				'text' => 'COM_REDSHOP_INSTALL_STEP_HANDLE_CONFIG',
+				'text' => JText::_('COM_REDSHOP_INSTALL_STEP_HANDLE_CONFIG'),
 				'func' => 'RedshopInstall::handleConfig'
 			)
 		);

--- a/component/site/controllers/order_detail.php
+++ b/component/site/controllers/order_detail.php
@@ -439,7 +439,7 @@ class RedshopControllerOrder_detail extends RedshopController
 
 		$orderId = $app->input->post->getInt('id');
 
-		$orderPaymentStatus = RedshopHelperOrder::getOrderDetail($orderId)->order_payment_status;
+		$orderPaymentStatus = RedshopEntityOrder::load($orderId)->get('order_payment_status');
 
 		$status = JText::_('COM_REDSHOP_PAYMENT_STA_UNPAID');
 

--- a/libraries/redshop/entities/collection.php
+++ b/libraries/redshop/entities/collection.php
@@ -40,9 +40,9 @@ class RedshopEntitiesCollection implements Countable, Iterator
 	 */
 	public function add(RedshopEntity $entity)
 	{
-		if ($entity->hasId() && !$this->has($entity->id))
+		if ($entity->hasId() && !$this->has($entity->getId()))
 		{
-			$this->entities[$entity->id] = $entity;
+			$this->entities[$entity->getId()] = $entity;
 		}
 
 		return $this;

--- a/libraries/redshop/entity/base.php
+++ b/libraries/redshop/entity/base.php
@@ -355,6 +355,26 @@ abstract class RedshopEntityBase
 	}
 
 	/**
+	 * Set an item property
+	 *
+	 * @param   string  $property  Property to get
+	 * @param   mixed   $data      Data for set to property
+	 *
+	 * @return  self
+	 */
+	public function set($property, $data = null)
+	{
+		if (null === $this->item)
+		{
+			$this->loadItem();
+		}
+
+		$this->item->{$property} = $data;
+
+		return $this;
+	}
+
+	/**
 	 * Get the ACL prefix applied to this class
 	 *
 	 * @return  string
@@ -935,6 +955,28 @@ abstract class RedshopEntityBase
 
 		static::loadFromTable($table);
 
-		return $table->id;
+		return $table->{$table->getKeyName()};
+	}
+
+	/**
+	 * Method for reset this static for load new data.
+	 *
+	 * @return  RedshopEntityBase
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function reset()
+	{
+		if (!$this->isLoaded())
+		{
+			return $this;
+		}
+
+		$class = get_called_class();
+		$id = $this->getId();
+
+		unset(static::$instances[$class][$id]);
+
+		return static::getInstance($id);
 	}
 }

--- a/libraries/redshop/entity/order.php
+++ b/libraries/redshop/entity/order.php
@@ -26,6 +26,34 @@ class RedshopEntityOrder extends RedshopEntity
 	protected $orderItems;
 
 	/**
+	 * @var   RedshopEntityOrder_Payment
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $payment;
+
+	/**
+	 * @var    RedshopEntitiesCollection
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $users;
+
+	/**
+	 * @var   RedshopEntityOrder_User
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $billing;
+
+	/**
+	 * @var   RedshopEntityOrder_User
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $shipping;
+
+	/**
 	 * Get the associated table
 	 *
 	 * @param   string  $name  Main name of the Table. Example: Article for ContentTableArticle
@@ -63,7 +91,7 @@ class RedshopEntityOrder extends RedshopEntity
 	/**
 	 * Method for get order items for this order
 	 *
-	 * @return   mixed   RedshopEntitiesCollection if success. Null otherwise.
+	 * @return   RedshopEntitiesCollection   RedshopEntitiesCollection if success. Null otherwise.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
@@ -80,6 +108,94 @@ class RedshopEntityOrder extends RedshopEntity
 		}
 
 		return $this->orderItems;
+	}
+
+	/**
+	 * Method for get payment for this order
+	 *
+	 * @return   RedshopEntityOrder_Payment   Payment data if success. Null otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getPayment()
+	{
+		if (!$this->hasId())
+		{
+			return null;
+		}
+
+		if (null === $this->payment)
+		{
+			$this->loadPayment();
+		}
+
+		return $this->payment;
+	}
+
+	/**
+	 * Method for get users of this order
+	 *
+	 * @return   RedshopEntitiesCollection   Collection of users if success. Null otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getUsers()
+	{
+		if (!$this->hasId())
+		{
+			return null;
+		}
+
+		if (null === $this->users)
+		{
+			$this->loadUsers();
+		}
+
+		return $this->users;
+	}
+
+	/**
+	 * Method for get billing information of this order
+	 *
+	 * @return   RedshopEntityOrder_User   User infor if success. Null otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getBilling()
+	{
+		if (!$this->hasId())
+		{
+			return null;
+		}
+
+		if (null === $this->billing)
+		{
+			$this->loadBilling();
+		}
+
+		return $this->billing;
+	}
+
+	/**
+	 * Method for get shipping information of this order
+	 *
+	 * @return   RedshopEntityOrder_User   User infor if success. Null otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getShipping()
+	{
+		if (!$this->hasId())
+		{
+			return null;
+		}
+
+		if (null === $this->shipping)
+		{
+			$this->loadShipping();
+		}
+
+		return $this->shipping;
 	}
 
 	/**
@@ -116,6 +232,145 @@ class RedshopEntityOrder extends RedshopEntity
 			$entity->bind($orderItem);
 
 			$this->orderItems->add($entity);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Method for load payment of this order
+	 *
+	 * @return  self
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadPayment()
+	{
+		if (!$this->hasId())
+		{
+			return $this;
+		}
+
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select('*')
+			->from($db->qn('#__redshop_order_payment'))
+			->where($db->qn('order_id') . ' = ' . (int) $this->getId());
+		$result = $db->setQuery($query)->loadObject();
+
+		if (empty($result))
+		{
+			return $this;
+		}
+
+		$this->payment = RedshopEntityOrder_Payment::getInstance($result->payment_order_id)->bind($result);
+		$this->payment->loadPlugin();
+
+		return $this;
+	}
+
+	/**
+	 * Method for load users of this order
+	 *
+	 * @return  self
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadUsers()
+	{
+		if (!$this->hasId())
+		{
+			return $this;
+		}
+
+		$this->users = new RedshopEntitiesCollection;
+
+		$db = JFactory::getDbo();
+
+		$query = $db->getQuery(true)
+			->select('*')
+			->from($db->qn('#__redshop_order_users_info'))
+			->where($db->qn('order_id') . ' = ' . (int) $this->getId());
+		$results = $db->setQuery($query)->loadObjectList();
+
+		if (empty($results))
+		{
+			return $this;
+		}
+
+		foreach ($results as $result)
+		{
+			$entity = RedshopEntityOrder_User::getInstance($result->order_info_id)->bind($result)->loadExtraFields();
+
+			$this->users->add($entity);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Method for load billing user information of this order
+	 *
+	 * @return  self
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadBilling()
+	{
+		if (!$this->hasId())
+		{
+			return $this;
+		}
+
+		$users = $this->getUsers();
+
+		if ($users->isEmpty())
+		{
+			return $this;
+		}
+
+		foreach ($users as $user)
+		{
+			if ($user->get('address_type') == 'BT')
+			{
+				$this->billing = $user;
+
+				return $this;
+			}
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Method for load shipping user information of this order
+	 *
+	 * @return  self
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadShipping()
+	{
+		if (!$this->hasId())
+		{
+			return $this;
+		}
+
+		$users = $this->getUsers();
+
+		if ($users->isEmpty())
+		{
+			return $this;
+		}
+
+		foreach ($users as $user)
+		{
+			if ($user->get('address_type') == 'ST')
+			{
+				$this->shipping = $user;
+
+				return $this;
+			}
 		}
 
 		return $this;

--- a/libraries/redshop/entity/order_item.php
+++ b/libraries/redshop/entity/order_item.php
@@ -19,6 +19,13 @@ defined('_JEXEC') or die;
 class RedshopEntityOrder_Item extends RedshopEntity
 {
 	/**
+	 * @var   RedshopEntitiesCollection
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $accessoryItems;
+
+	/**
 	 * Get the associated table
 	 *
 	 * @param   string  $name  Main name of the Table. Example: Article for ContentTableArticle
@@ -48,6 +55,68 @@ class RedshopEntityOrder_Item extends RedshopEntity
 		if (($table = $this->getTable()) && $table->load(array($key => ($key == 'order_item_id' ? $this->id : $keyValue))))
 		{
 			$this->loadFromTable($table);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Method for get accessory items for this order item
+	 *
+	 * @return   RedshopEntitiesCollection   RedshopEntitiesCollection if success. Null otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getAccessoryItems()
+	{
+		if (!$this->hasId())
+		{
+			return null;
+		}
+
+		if (null === $this->accessoryItems)
+		{
+			$this->loadAccessoryItems();
+		}
+
+		return $this->accessoryItems;
+	}
+
+	/**
+	 * Method for load accessory items for this order item
+	 *
+	 * @return  self
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadAccessoryItems()
+	{
+		if (!$this->hasId())
+		{
+			return $this;
+		}
+
+		$this->accessoryItems = new RedshopEntitiesCollection;
+
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select('*')
+			->from($db->qn('#__redshop_order_acc_item'))
+			->where($db->qn('order_item_id') . ' = ' . $this->getId());
+		$items = $db->setQuery($query)->loadObjectList();
+
+		if (empty($items))
+		{
+			return $this;
+		}
+
+		foreach ($items as $item)
+		{
+			$entity = RedshopEntityOrder_Item_Accessory::getInstance($item->order_item_acc_id);
+
+			$entity->bind($item);
+
+			$this->accessoryItems->add($entity);
 		}
 
 		return $this;

--- a/libraries/redshop/entity/order_payment.php
+++ b/libraries/redshop/entity/order_payment.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Order Payment Entity
  *
@@ -48,6 +50,36 @@ class RedshopEntityOrder_Payment extends RedshopEntity
 		if (($table = $this->getTable()) && $table->load(array($key => ($key == 'payment_order_id' ? $this->id : $keyValue))))
 		{
 			$this->loadFromTable($table);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Method for load plugin data of this payment
+	 *
+	 * @return  self
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function loadPlugin()
+	{
+		if (!$this->hasId() || !is_null($this->get('plugin', null)))
+		{
+			return $this;
+		}
+
+		if (!empty($this->get('payment_method_class')))
+		{
+			// Get plugin information
+			$plugin = JPluginHelper::getPlugin('redshop_payment', $this->get('payment_method_class'));
+
+			if ($plugin)
+			{
+				$plugin->params = new Registry($plugin->params);
+			}
+
+			$this->set('plugin', $plugin);
 		}
 
 		return $this;

--- a/libraries/redshop/entity/order_user.php
+++ b/libraries/redshop/entity/order_user.php
@@ -23,7 +23,7 @@ class RedshopEntityOrder_User extends RedshopEntity
 	 *
 	 * @param   string  $name  Main name of the Table. Example: Article for ContentTableArticle
 	 *
-	 * @return  RedshopTable
+	 * @return  JTable
 	 */
 	public function getTable($name = null)
 	{
@@ -49,6 +49,68 @@ class RedshopEntityOrder_User extends RedshopEntity
 		{
 			$this->loadFromTable($table);
 		}
+
+		return $this;
+	}
+
+	/**
+	 * Method for load plugin data of this payment
+	 *
+	 * @return  self
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function loadExtraFields()
+	{
+		if (!$this->hasId() || !is_null($this->get('fields', null)))
+		{
+			return $this;
+		}
+
+		$this->set('email', $this->get('user_email'));
+
+		$privateSection = extraField::SECTION_PRIVATE_BILLING_ADDRESS;
+		$companySection = extraField::SECTION_COMPANY_BILLING_ADDRESS;
+
+		if ($this->get('address_type', '') == 'ST')
+		{
+			$privateSection = extraField::SECTION_PRIVATE_SHIPPING_ADDRESS;
+			$companySection = extraField::SECTION_COMPANY_SHIPPING_ADDRESS;
+		}
+
+		$db = JFactory::getDbo();
+
+		$query = $db->getQuery(true)
+			->select($db->qn('f.name') . ',' . $db->qn('fd.data_txt'))
+			->from($db->qn('#__redshop_fields_data', 'fd'))
+			->leftJoin($db->qn('#__redshop_fields', 'f') . ' ON ' . $db->qn('f.id') . '=' . $db->qn('fd.fieldid'))
+			->where(
+				'('
+				. $db->qn('fd.section') . ' = ' . $privateSection
+				. ' OR '
+				. $db->qn('fd.section') . ' = ' . $companySection
+				. ')'
+			)
+			->where($db->qn('fd.itemid') . ' = ' . $this->get('users_info_id'));
+
+		// Set the query and load the result.
+		$results = $db->setQuery($query)->loadObjectList();
+
+		if (empty($results))
+		{
+			$this->set('fields', array());
+
+			return $this;
+		}
+
+		$fieldsData = array();
+
+		foreach ($results as $result)
+		{
+			$fieldsData[$result->name] = $result->data_txt;
+		}
+
+		$this->set('fields', $fieldsData);
 
 		return $this;
 	}

--- a/libraries/redshop/entity/subcription.php
+++ b/libraries/redshop/entity/subcription.php
@@ -16,7 +16,7 @@ defined('_JEXEC') or die;
  * @subpackage  Entity
  * @since       __DEPLOY_VERSION__
  */
-class RedshopEntityDiscount extends RedshopEntity
+class RedshopEntitySubscription extends RedshopEntity
 {
 	/**
 	 * Get the associated table

--- a/libraries/redshop/helper/order.php
+++ b/libraries/redshop/helper/order.php
@@ -568,7 +568,7 @@ class RedshopHelperOrder
 		// If not an integer then convert it into an integer
 		if (!is_int($orderId))
 		{
-			throw new InvalidArgumentException($orderId . " is not valid Integer. Passed argument is " . getType($orderId));
+			throw new InvalidArgumentException($orderId . " is not valid Integer. Passed argument is " . gettype($orderId));
 		}
 
 		$key = $orderId;

--- a/libraries/redshop/src/Economic/Economic.php
+++ b/libraries/redshop/src/Economic/Economic.php
@@ -1058,11 +1058,11 @@ class Economic
 		if ($orderData->is_booked == 0)
 		{
 			$data        = array();
-			$paymentInfo = \RedshopHelperOrder::getOrderPaymentDetail($orderData->order_id);
+			$paymentInfo = \RedshopHelperOrder::getPaymentInfo($orderData->order_id);
 
-			if (count($paymentInfo) > 0)
+			if ($paymentInfo)
 			{
-				$paymentName = $paymentInfo[0]->payment_method_class;
+				$paymentName = $paymentInfo->payment_method_class;
 				$paymentArr  = explode("rs_payment_", $paymentInfo[0]->payment_method_class);
 
 				if (count($paymentArr) > 0)
@@ -1071,7 +1071,7 @@ class Economic
 				}
 
 				$data['economic_payment_method'] = $paymentName;
-				$paymentMethod                   = \RedshopHelperOrder::getPaymentMethodInfo($paymentInfo[0]->payment_method_class);
+				$paymentMethod                   = \RedshopHelperOrder::getPaymentMethodInfo($paymentInfo->payment_method_class);
 
 				if (count($paymentMethod) > 0)
 				{
@@ -1265,11 +1265,11 @@ class Economic
 								$eco['name'] = $userBillingInfo->firstname . " " . $userBillingInfo->lastname;
 							}
 
-							$paymentInfo = \RedshopHelperOrder::getOrderPaymentDetail($orderDetail->order_id);
+							$paymentInfo = \RedshopHelperOrder::getPaymentInfo($orderDetail->order_id);
 
-							if (count($paymentInfo) > 0)
+							if ($paymentInfo)
 							{
-								$paymentMethod = \RedshopHelperOrder::getPaymentMethodInfo($paymentInfo[0]->payment_method_class);
+								$paymentMethod = \RedshopHelperOrder::getPaymentMethodInfo($paymentInfo->payment_method_class);
 
 								if (count($paymentMethod) > 0)
 								{
@@ -1279,9 +1279,9 @@ class Economic
 								}
 
 								// Setting merchant fees for economic
-								if ($paymentInfo[0]->order_transfee > 0)
+								if ($paymentInfo->order_transfee > 0)
 								{
-									$eco['order_transfee'] = $paymentInfo[0]->order_transfee;
+									$eco['order_transfee'] = $paymentInfo->order_transfee;
 								}
 							}
 

--- a/plugins/redshop_payment/paypalcreditcard/paypalcreditcard.php
+++ b/plugins/redshop_payment/paypalcreditcard/paypalcreditcard.php
@@ -745,7 +745,7 @@ class plgRedshop_PaymentPaypalCreditcard extends RedshopPaypalPayment
 	{
 		$app = JFactory::getApplication();
 
-		$orderInfo = RedshopHelperOrder::getOrderDetail($orderId);
+		$orderInfo = RedshopEntityOrder::getInstance($orderId)->getItem();
 
 		// Only pay when order status is set to pending and unpaid.
 		if ('P' != $orderInfo->order_status && 'Unpaid' != $orderInfo->order_payment_status)


### PR DESCRIPTION
Speed performance:
`RedshopEntityOrder::getInstance()->getOrderItems()` vs `RedshopHelperOrder::getItems()`

Run 100 times:
**Entity**
- Execution time: 2.96 ms
- Memory usage: 157.128 KB

**Helper**
- Execution time: 3.84 ms
- Memory usage: 618.072 KB


Run 1000 times:
**Entity**
- Execution time: 8.32 ms
- Memory usage: 157.128 KB

**Helper**
- Execution time: 6.50 ms
- Memory usage: 618.072 KB