### PR TITLE
[Travis] Change to use nodeJS version 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ php:
   - 7.0
 install:
   - . $HOME/.nvm/nvm.sh
-  - nvm install stable
-  - nvm use stable
+  - nvm install 6
+  - nvm use 6
   - npm install
 addons:
   firefox: "46.0"


### PR DESCRIPTION
Travis is currently use NodeJS `8.x`, it would fail when try to install gulp-sass (dependecy is node-sass).

This is force to use NodeJS `6.x` for supported version on gulp-sass.