### PR TITLE
Fix Container Test LoadTask Issue

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -17,7 +17,7 @@ require_once 'vendor/autoload.php';
 class RoboFile extends \Robo\Tasks
 {
 	// Load tasks from composer, see composer.json
-	use Joomla\Testing\Robo\Tasks\loadTasks;
+	use Joomla\Testing\Robo\Tasks\LoadTasks;
 
 	/**
 	 * File extension for executables


### PR DESCRIPTION
This should fix the failure for ``PHP Fatal error:  Trait 'Joomla\Testing\Robo\Tasks\loadTasks' not found in /var/lib/jenkins/workspace/redSHOP/RoboFile.php``