### PR TITLE
RSC-124 Fix fail transaction in Paypal plugin "rs_payment_paypal"

### DIFF
--- a/plugins/redshop_payment/rs_payment_paypal/rs_payment_paypal/extra_info.php
+++ b/plugins/redshop_payment/rs_payment_paypal/rs_payment_paypal/extra_info.php
@@ -76,19 +76,6 @@ $paypalPostData = Array(
 	'bn'                 => 'redCOMPONENT_SP'
 );
 
-if (Redshop::getConfig()->get('SHIPPING_METHOD_ENABLE'))
-{
-	$paypalShippingData = Array(
-		"address1"   => $data['shippinginfo']->address,
-		"city"       => $data['shippinginfo']->city,
-		"country"    => $data['shippinginfo']->country_2_code,
-		"first_name" => $data['shippinginfo']->firstname,
-		"last_name"  => $data['shippinginfo']->lastname,
-		"state"      => $data['shippinginfo']->state_code,
-		"zip"        => $data['shippinginfo']->zipcode
-	);
-}
-
 $paypalPostData['discount_amount_cart'] = round(RedshopHelperCurrency::convert($data['order']->order_discount, '', $paymentCurrency), 2);
 $paypalPostData['discount_amount_cart'] += round(RedshopHelperCurrency::convert($data['order']->special_discount, '', $paymentCurrency), 2);
 

--- a/tests/acceptance/administrator/_steps/Joomla3Steps/ProductManagerJoomla3Steps.php
+++ b/tests/acceptance/administrator/_steps/Joomla3Steps/ProductManagerJoomla3Steps.php
@@ -171,7 +171,6 @@ class ProductManagerJoomla3Steps extends AdminManagerJoomla3Steps
         $I->fillField(\ProductManagerPage::$maximumQuantity, $maximumQuantity);
         $I->click("Save");
         $I->waitForText('Product details saved', 30, ['class' => 'alert-success']);
-        $I->see('Product details saved', ['class' => 'alert-success']);
     }
 
     public function createProductMissingName($productCategory, $productNumber, $price)


### PR DESCRIPTION
Those params are redundant and should be removed.
The fix is confirmed to work by many clients