### PR TITLE
[Fix] wrong condition check when saving a voucher (if no products assigned to the voucher)

### DIFF
--- a/component/admin/tables/voucher.php
+++ b/component/admin/tables/voucher.php
@@ -140,7 +140,7 @@ class RedshopTableVoucher extends RedshopTable
 
 		$products = $this->getOption('products', null);
 
-		if (empty($products))
+		if (empty(array_filter($products)))
 		{
 			return true;
 		}


### PR DESCRIPTION

![workspace 1_149](https://user-images.githubusercontent.com/16286639/29014331-b13c563a-7b72-11e7-866b-70732e0e4b29.png)

If we leave empty for the fields "Products" and save

$products = $this->getOption('products', null);
**empty($products)** is always false value, although we don't add any product to voucher

It cause a row will be insert to the table `#__redshop_product_voucher_xref` with product_id = 0 (????)