### PR TITLE
Fix bug on php 7 for export order function :  syntax [] operator not supported for strings

### DIFF
--- a/component/admin/models/order.php
+++ b/component/admin/models/order.php
@@ -185,10 +185,7 @@ class RedshopModelOrder extends RedshopModel
 
 	public function export_data($cid)
 	{
-		$where = "";
-
 		$order_id = implode(',', $cid);
-
 
 		$where[] = " 1=1";
 

--- a/component/admin/models/order.php
+++ b/component/admin/models/order.php
@@ -185,6 +185,7 @@ class RedshopModelOrder extends RedshopModel
 
 	public function export_data($cid)
 	{
+		$where = array();
 		$order_id = implode(',', $cid);
 
 		$where[] = " 1=1";


### PR DESCRIPTION
Client reported this, so I made a pull request. On PHP 7 the rule for initializing variable is more strictly

![workspace 1_378](https://user-images.githubusercontent.com/16286639/31874934-f1a39f66-b7f5-11e7-9a32-972aa0a321a6.png)


