### PR TITLE
REDSHOP-4758 Fix fatal error when update order in backend (green button) - Economic error

### DIFF
--- a/libraries/redshop/src/Economic/Economic.php
+++ b/libraries/redshop/src/Economic/Economic.php
@@ -1063,7 +1063,7 @@ class Economic
 			if ($paymentInfo)
 			{
 				$paymentName = $paymentInfo->payment_method_class;
-				$paymentArr  = explode("rs_payment_", $paymentInfo[0]->payment_method_class);
+				$paymentArr  = explode("rs_payment_", $paymentInfo->payment_method_class);
 
 				if (count($paymentArr) > 0)
 				{


### PR DESCRIPTION
Click on the green button "update_order" in order detail -> Fatal Error: **_"Can not use object of type stdClass as array"_**

