### PR TITLE
REDSHOP-4824  Fix wrong display of categories tree list in product detail backend after adding categories to product and save

### DIFF
--- a/component/admin/helpers/product_category.php
+++ b/component/admin/helpers/product_category.php
@@ -65,22 +65,22 @@ class product_category
 	 * List children of category into dropdown with level,
 	 * this is a function will be called resursively.
 	 *
-	 * @param   string  $category_id          Exclude this category ID
-	 * @param   string  $cid                  Parent category ID
-	 * @param   string  $level                Default is 0
-	 * @param   array   $selected_categories  Only show selected categories
-	 * @param   array   $disabledFields       Didable fields
-	 * @param   string  $html                 Before HTML
+	 * @param   string $categoryId         Exclude this category ID
+	 * @param   string $cid                Parent category ID
+	 * @param   string $level              Default is 0
+	 * @param   array  $selectedCategories Only show selected categories
+	 * @param   array  $disabledFields     Didable fields
+	 * @param   string $html               Before HTML
 	 *
-	 * @return String   HTML of <option></option>
+	 * @return  string   HTML of <option></option>
 	 *
 	 * @deprecated  2.0.0.3 Use RedshopHelperCategory::listTree() instead
+	 *
+	 * @throws  Exception
 	 */
-	public function list_tree($category_id = "", $cid = '0', $level = '0', $selected_categories = Array(),
-		$disabledFields = Array(), $html = ''
-	)
+	public function list_tree($categoryId = "", $cid = '0', $level = '0', $selectedCategories = Array(), $disabledFields = Array(), $html = '')
 	{
-		return RedshopHelperCategory::listTree($category_id, $cid, $level, $selected_categories, $disabledFields, $html);
+		return RedshopHelperCategory::listTree($selectedCategories, $disabledFields);
 	}
 
 	/**

--- a/libraries/redshop/helper/category.php
+++ b/libraries/redshop/helper/category.php
@@ -202,6 +202,7 @@ class RedshopHelperCategory
 			foreach ($cats as $cat)
 			{
 				$cat->name = str_repeat('- ', $level) . $cat->name;
+
 				static::$categoryChildListReverse[$key][] = $cat;
 				self::getCategoryChildListRecursion($key, $cat->id, $level);
 			}
@@ -222,7 +223,9 @@ class RedshopHelperCategory
 	 *
 	 * @return  string   HTML of dropdown
 	 *
-	 * @since  2.0.0.3
+	 * @since   2.0.0.3
+	 *
+	 * @throws  Exception
 	 */
 	public static function listAll($name, $categoryId, $selectedCategories = array(), $size = 1, $topLevel = false,
 	                               $multiple = false, $disabledFields = array(), $width = 250)
@@ -252,7 +255,7 @@ class RedshopHelperCategory
 
 		$multiple = $multiple ? "multiple=\"multiple\"" : "";
 		$id       = str_replace('[]', '', $name);
-		$html     .= "<select class=\"inputbox\" style=\"width: " . $width . "px;\" size=\"$size\" $multiple name=\"$name\" id=\"$id\">\n";
+		$html    .= "<select class=\"inputbox\" style=\"width: " . $width . "px;\" size=\"$size\" $multiple name=\"$name\" id=\"$id\">\n";
 
 		if ($topLevel)
 		{
@@ -267,14 +270,16 @@ class RedshopHelperCategory
 
 	/**
 	 * List children of category into dropdown with level,
-	 * this is a function will be called resursively.
+	 * this is a function will be called recursively.
 	 *
 	 * @param   array   $selectedCategories  Only show selected categories
-	 * @param   array   $disabledFields      Didable fields
+	 * @param   array   $disabledFields      Disable fields
 	 *
-	 * @return String   HTML of <option></option>
+	 * @return  string                       HTML of <option></option>
 	 *
-	 * @since  2.0.0.3
+	 * @since   2.0.0.3
+	 *
+	 * @throws  Exception
 	 */
 	public static function listTree($selectedCategories = array(), $disabledFields = array())
 	{
@@ -299,28 +304,25 @@ class RedshopHelperCategory
 		{
 			$options = $db->loadObjectList();
 		}
-		catch (RuntimeException $e)
+		catch (RuntimeException $exception)
 		{
-			JError::raiseWarning(500, $e->getMessage());
-		}
-
-		// Pad the option text with spaces using depth level as a multiplier.
-		for ($i = 0, $n = count($options); $i < $n; $i++)
-		{
-			if ($options[$i]->published == 1)
-			{
-				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
-			}
-			else
-			{
-				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ']';
-			}
+			throw new Exception($exception->getMessage(), 500);
 		}
 
 		$html = "";
 
 		foreach ($options as $key => $option)
 		{
+			// Pad the option text with spaces using depth level as a multiplier.
+			if ($option->published == 1)
+			{
+				$option->text = str_repeat('- ', $option->level) . $option->text;
+			}
+			else
+			{
+				$option->text = str_repeat('- ', $option->level) . '[' . $option->text . ']';
+			}
+
 			$selected = '';
 			$disabled = '';
 

--- a/libraries/redshop/helper/category.php
+++ b/libraries/redshop/helper/category.php
@@ -259,7 +259,7 @@ class RedshopHelperCategory
 			$html .= "<option value=\"0\"> -Top- </option>\n";
 		}
 
-		$html .= self::listTree($categoryId, '0', '0', $selectedCategories, $disabledFields);
+		$html .= self::listTree($selectedCategories, $disabledFields);
 		$html .= "</select>\n";
 
 		return $html;
@@ -269,78 +269,72 @@ class RedshopHelperCategory
 	 * List children of category into dropdown with level,
 	 * this is a function will be called resursively.
 	 *
-	 * @param   string  $categoryId          Exclude this category ID
-	 * @param   string  $cid                 Parent category ID
-	 * @param   string  $level               Default is 0
 	 * @param   array   $selectedCategories  Only show selected categories
 	 * @param   array   $disabledFields      Didable fields
-	 * @param   string  $html                Before HTML
 	 *
 	 * @return String   HTML of <option></option>
 	 *
 	 * @since  2.0.0.3
 	 */
-	public static function listTree($categoryId = "", $cid = '0', $level = '0', $selectedCategories = array(),
-	                                $disabledFields = array(), $html = '')
+	public static function listTree($selectedCategories = array(), $disabledFields = array())
 	{
 		$db = JFactory::getDbo();
-		$level++;
 
 		$query = $db->getQuery(true)
-			->select($db->qn(array('id', 'name')))
-			->from($db->qn('#__redshop_category'))
-			->where($db->qn('id') . ' != ' . $db->q((int) $categoryId))
-			->where($db->qn('level') . ' > 0')
-			->order($db->qn('name') . ' ASC');
+			->select('DISTINCT a.id AS value, a.name AS text, a.level, a.published, a.lft');
 
-		if ($cid > 0)
+		$subQuery = $db->getQuery(true)
+			->select('id, name, level, published, parent_id, lft, rgt')
+			->from('#__redshop_category');
+
+		$query->from('(' . (string) $subQuery . ') AS a')
+			->join('LEFT', $db->qn('#__redshop_category') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt')
+			->where($db->qn('a.level') . ' > 0');
+		$query->order('a.lft ASC');
+
+		// Get the options.
+		$db->setQuery($query);
+
+		try
 		{
-			$query->where($db->qn('parent_id') . ' = ' . $db->q((int) $cid));
+			$options = $db->loadObjectList();
+		}
+		catch (RuntimeException $e)
+		{
+			JError::raiseWarning(500, $e->getMessage());
 		}
 
-		$db->setQuery($query);
-		$cats = $db->loadObjectList();
-
-		for ($x = 0, $xn = count($cats); $x < $xn; $x++)
+		// Pad the option text with spaces using depth level as a multiplier.
+		for ($i = 0, $n = count($options); $i < $n; $i++)
 		{
-			$cat = $cats[$x];
-			$childId = $cat->id;
-
-			if ($childId != $cid)
+			if ($options[$i]->published == 1)
 			{
-				$selected = ($childId == $categoryId) ? "selected=\"selected\"" : "";
+				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
+			}
+			else
+			{
+				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ']';
+			}
+		}
 
-				if ($selected == "" && @$selectedCategories[$childId] == "1")
-				{
-					$selected = "selected=\"selected\"";
-				}
+		$html = "";
 
-				if (is_array($selectedCategories))
-				{
-					if (in_array($childId, $selectedCategories))
-					{
-						$selected = "selected=\"selected\"";
-					}
-				}
+		foreach ($options as $key => $option)
+		{
+			$selected = '';
+			$disabled = '';
 
-				$disabled = '';
-
-				if (in_array($childId, $disabledFields))
-				{
-					$disabled = 'disabled="disabled"';
-				}
-
-				if ($disabled != '' && stristr($_SERVER['HTTP_USER_AGENT'], 'msie'))
-				{
-					// IE7 suffers from a bug, which makes disabled option fields selectable
-				}
-				else
-				{
-					$html .= "<option $selected $disabled value=\"$childId\">" . str_repeat('- ', $level) . $cat->name . "</option>";
-				}
+			if (in_array($option->value, $selectedCategories))
+			{
+				$selected = ' selected="selected" ';
 			}
 
-			$html .= self::listTree($categoryId, $childId, $level, $selectedCategories, $disabledFields);
+			if (in_array($option->value, $disabledFields))
+			{
+				$disabled = ' disabled="disabled" ';
+			}
+
+			$html .= '<option ' . $selected . $disabled . ' value="' . $option->value . '">' . $option->text . '</option>';
 		}
 
 		return $html;


### PR DESCRIPTION
We should change the helper function to use the same code as written in 
 **/libraries/redshop/form/fields/categorylist.php**   to show correct hierarchy tree list.

This is to fix the display problem, save function still work fine and not be affected.
