### PR TITLE
REDSHOP-4823 When re-order customfield, value of customfield missed.

### DIFF
--- a/component/admin/tables/field.php
+++ b/component/admin/tables/field.php
@@ -210,22 +210,26 @@ class RedshopTableField extends RedshopTable
 			}
 		}
 
-		$fieldDataIds = RedshopEntityField::getInstance($id)->getFieldValues();
-
-		if (count($fieldDataIds) > 0)
+		// Do not reset values if we are ordering
+		if ($app->input->get('task') != 'fields.saveOrderAjax')
 		{
-			$fid = array();
+			$fieldDataIds = RedshopEntityField::getInstance($id)->getFieldValues();
 
-			foreach ($fieldDataIds as $fieldDataId)
+			if (count($fieldDataIds) > 0)
 			{
-				$fid[] = $fieldDataId->value_id;
-			}
+				$fid = array();
 
-			$delFieldIds = array_diff($fid, $valueIds);
+				foreach ($fieldDataIds as $fieldDataId)
+				{
+					$fid[] = $fieldDataId->value_id;
+				}
 
-			if (count($delFieldIds) > 0)
-			{
-				$this->deleteFieldValues($delFieldIds, 'value_id');
+				$delFieldIds = array_diff($fid, $valueIds);
+
+				if (count($delFieldIds) > 0)
+				{
+					$this->deleteFieldValues($delFieldIds, 'value_id');
+				}
 			}
 		}
 

--- a/component/admin/tables/field.php
+++ b/component/admin/tables/field.php
@@ -206,7 +206,7 @@ class RedshopTableField extends RedshopTable
 			else
 			{
 				$extraNames = $post->get('extra_name', '', 'raw');
-				$total      = count($extraNames);
+				$total      = count((array)$extraNames);
 			}
 		}
 


### PR DESCRIPTION
This issue caused because
- Ordering custom fields
- It will call table for saving ( ordering )
- But in table when saving we also do reset values and update new values - but in this case no new values, so all data lost.

At the moment i fixed by check on task. But consider should we make another function like doOrdering similar onPublish.

cc @thongredweb 