### PR TITLE
REDSHOP-4760 Ajax Onestep:  remove tags of payment template if anonymous

### DIFF
--- a/component/site/models/cart.php
+++ b/component/site/models/cart.php
@@ -59,12 +59,11 @@ class RedshopModelCart extends RedshopModel
 		$this->_userhelper    = rsUserHelper::getInstance();
 		$this->_objshipping   = shipping::getInstance();
 		$user                 = JFactory::getUser();
-		$session              = JFactory::getSession();
 
 		// Remove expired products from cart
 		$this->emptyExpiredCartProducts();
 
-		$cart = $session->get('cart');
+		$cart = RedshopHelperCartSession::getCart();
 
 		if (!empty($cart))
 		{
@@ -75,7 +74,7 @@ class RedshopModelCart extends RedshopModel
 			}
 
 			$user_id        = $user->id;
-			$usersess       = $session->get('rs_user');
+			$usersess       = JFactory::getSession()->get('rs_user');
 			$shopperGroupId = RedshopHelperUser::getShopperGroup($user_id);
 
 			if (array_key_exists('user_shopper_group_id', $cart))
@@ -99,7 +98,7 @@ class RedshopModelCart extends RedshopModel
 				}
 			}
 
-			RedshopHelperCartSession::setCart($cart);
+			RedshopHelperCartSession::setCart((array) $cart);
 		}
 	}
 

--- a/component/site/models/checkout.php
+++ b/component/site/models/checkout.php
@@ -2050,7 +2050,7 @@ class RedshopModelCheckout extends RedshopModel
 	public function displayShoppingCart($template_desc = "", $users_info_id, $shipping_rate_id = 0, $payment_method_id, $Itemid, $customer_note = "", $req_number = "", $thirdparty_email = "", $customer_message = "", $referral_code = "", $shop_id = "", $post = array())
 	{
 		$session  = JFactory::getSession();
-		$cart     = $session->get('cart');
+		$cart     = RedshopHelperCartSession::getCart();
 		$user     = JFactory::getUser();
 		$user_id  = $user->id;
 		$usersess = $session->get('rs_user');
@@ -2278,7 +2278,7 @@ class RedshopModelCheckout extends RedshopModel
 		$template_desc = $this->_carthelper->replaceLabel($template_desc);
 		$template_desc = str_replace("{print}", '', $template_desc);
 
-		RedshopHelperCartSession::setCart($cart);
+		RedshopHelperCartSession::setCart((array) $cart);
 
 		return $template_desc;
 	}

--- a/component/site/views/checkout/tmpl/onestepcheckout.php
+++ b/component/site/views/checkout/tmpl/onestepcheckout.php
@@ -284,9 +284,12 @@ JDispatcher::getInstance()->trigger('onRenderInvoiceOnstepCheckout', array (&$on
 if ($users_info_id && !empty($billingaddresses))
 {
 	$payment_template_desc = $carthelper->replacePaymentTemplate($payment_template_desc, $payment_method_id, $isCompany, $ean_number);
+	$onestep_template_desc = str_replace($payment_template, $payment_template_desc, $onestep_template_desc);
 }
-
-$onestep_template_desc = str_replace($payment_template, $payment_template_desc, $onestep_template_desc);
+else
+{
+	$onestep_template_desc = str_replace($payment_template, "<div hidden>" . $payment_template_desc . "</div>", $onestep_template_desc);
+}
 
 $onestep_template_desc = $model->displayShoppingCart($onestep_template_desc, $users_info_id, $shipping_rate_id, $payment_method_id, $Itemid);
 

--- a/component/site/views/checkout/tmpl/onestepcheckout.php
+++ b/component/site/views/checkout/tmpl/onestepcheckout.php
@@ -288,7 +288,7 @@ if ($users_info_id && !empty($billingaddresses))
 }
 else
 {
-	$onestep_template_desc = str_replace($payment_template, "<div hidden>" . $payment_template_desc . "</div>", $onestep_template_desc);
+	$onestep_template_desc = str_replace($payment_template, "", $onestep_template_desc);
 }
 
 $onestep_template_desc = $model->displayShoppingCart($onestep_template_desc, $users_info_id, $shipping_rate_id, $payment_method_id, $Itemid);

--- a/libraries/redshop/helper/cart.php
+++ b/libraries/redshop/helper/cart.php
@@ -764,7 +764,7 @@ abstract class RedshopHelperCart
 	public static function cartFinalCalculation($isModify = true)
 	{
 		$ajax = JFactory::getApplication()->input->get('ajax_cart_box');
-		$cart = JFactory::getSession()->get('cart');
+		$cart = RedshopHelperCartSession::getCart();
 
 		if ($isModify === true)
 		{


### PR DESCRIPTION
On checkout page (final), if user is unknown, the non-replaced tags of payment template still show on page render (after that ajax function will be called and replace those tags) => it looks unprofessional in terms of user experience, so tags should be blank on page initializing

See my video in below link to understand what was the problem:

https://drive.google.com/open?id=1EZgCaxFRGgLcLqqNU-CXC5hB4Z2U6Qeg

