### PR TITLE
REDSHOP-5274 "Lightbox" option for product image not work on frontend (product page)

### DIFF
--- a/libraries/redshop/src/Product/Image/Render.php
+++ b/libraries/redshop/src/Product/Image/Render.php
@@ -39,6 +39,7 @@ class Render
 		$isLight = 2, $enableHover = 0, $preSelectedResult = array(), $suffixId = ''
 	)
 	{
+		$isLight       = (int) $isLight;
 		$imageName     = trim($imageName);
 		$linkImageName = trim($linkImageName);
 		$productId     = $product->product_id;


### PR DESCRIPTION
I do `var_dump($isLight)`  and see it is a string so the tripple comparing sign **===** , **!==**  will not work correctly.