### PR TITLE
REDSHOP-4566: fix header product price page. The webpage display text incorrect

### DIFF
--- a/component/admin/views/product/view.html.php
+++ b/component/admin/views/product/view.html.php
@@ -78,6 +78,11 @@ class RedshopViewProduct extends RedshopViewAdmin
 			$this->addToolbar();
 		}
 
+        if ($layout == 'listing')
+        {
+            JToolBarHelper::title(JText::_('Product Price Managment'), 'stack redshop_products48');
+        }
+
 		$state       = $this->get('State');
 		$category_id = $state->get('category_id');
 


### PR DESCRIPTION
I fix display text incorrect header product price page.
I changed code file 
component/admin/views/product/view.html.php