### PR TITLE
Fix state display none

### DIFF
--- a/component/admin/views/addorder_detail/tmpl/default.php
+++ b/component/admin/views/addorder_detail/tmpl/default.php
@@ -392,16 +392,12 @@ $app->setUserState('com_redshop.addorder_detail.guestuser.username', null);
                                     <td align="right"><?php echo JText::_('COM_REDSHOP_STATE'); ?>:</td>
                                     <td><?php echo $this->lists['state_code']; ?></td>
                                 </tr>
-
                                 <script type="text/javascript" language="javascript">
-                                    ///alert(document.getElementById('state_code').options[1].value);
-
-                                    if (document.getElementById('state_code')) {
-                                        if (document.getElementById('state_code').options[1] == undefined) {
+                                    if (document.getElementById('rs_state_state_code')) {
+                                        if (document.getElementById('rs_state_state_code').options[1] == undefined) {
                                             document.getElementById('div_state_txt').style.display = 'none';
                                         }
                                     }
-
                                 </script>
                                 <tr>
                                     <td align="right"><?php echo JText::_('COM_REDSHOP_PHONE'); ?>:</td>

--- a/component/admin/views/addorder_detail/tmpl/default.php
+++ b/component/admin/views/addorder_detail/tmpl/default.php
@@ -534,8 +534,8 @@ $app->setUserState('com_redshop.addorder_detail.guestuser.username', null);
                                         <td><?php echo $this->lists['state_code_ST']; ?></td>
                                     </tr>
                                     <script type="text/javascript" language="javascript">
-                                        if (document.getElementById('state_code_ST')) {
-                                            if (document.getElementById('state_code_ST').options[1] == undefined) {
+                                        if (document.getElementById('rs_state_state_code_ST')) {
+                                            if (document.getElementById('rs_state_state_code_ST').options[1] == undefined) {
                                                 document.getElementById('div_state_st_txt').style.display = 'none';
                                             }
                                         }

--- a/component/admin/views/order_detail/tmpl/default.php
+++ b/component/admin/views/order_detail/tmpl/default.php
@@ -513,12 +513,13 @@ for ($t = 0; $t < $totalDownloadProduct; $t++) {
                                             RedshopHelperOrder::getCountryName($billing->country_code)
                                         ) : ''; ?></td>
                                 </tr>
-                                <tr>
-                                    <td align="right"><?php echo JText::_('COM_REDSHOP_STATE'); ?>:</td>
-                                    <td><?php echo (!empty($billing->state_code)) ? RedshopHelperOrder::getStateName(
+                                <?php $state = ($billing->state_code) ? RedshopHelperOrder::getStateName(
                                             $billing->state_code,
                                             $billing->country_code
-                                        ) : ''; ?></td>
+                                        ) : ''; ?>
+                                <tr <?php if (empty($state)) {echo "style='display:none;'";} ?> >
+                                    <td align="right"><?php echo JText::_('COM_REDSHOP_STATE'); ?>:</td>
+                                    <td><?php echo $state; ?></td>
                                 </tr>
                                 <tr>
                                     <td align="right"><?php echo JText::_('COM_REDSHOP_PHONE'); ?>:</td>
@@ -611,12 +612,13 @@ for ($t = 0; $t < $totalDownloadProduct; $t++) {
                                             RedshopHelperOrder::getCountryName($shipping->country_code)
                                         ) : ''); ?></td>
                                 </tr>
-                                <tr>
-                                    <td align="right"><?php echo JText::_('COM_REDSHOP_STATE'); ?>:</td>
-                                    <td><?php echo(!empty($shipping->state_code) ? RedshopHelperOrder::getStateName(
+                                <?php $state_ST = ($shipping->state_code) ? RedshopHelperOrder::getStateName(
                                             $shipping->state_code,
                                             $shipping->country_code
-                                        ) : ''); ?></td>
+                                        ) : ''; ?>
+                                <tr <?php if (empty($state_ST)) {echo "style='display:none;'";} ?> >
+                                    <td align="right"><?php echo JText::_('COM_REDSHOP_STATE'); ?>:</td>
+                                    <td><?php echo $state_ST; ?></td>
                                 </tr>
                                 <tr>
                                     <td align="right"><?php echo JText::_('COM_REDSHOP_PHONE'); ?>:</td>

--- a/component/admin/views/user_detail/tmpl/default_billing.php
+++ b/component/admin/views/user_detail/tmpl/default_billing.php
@@ -102,22 +102,29 @@ $stateStyle   = (isset($this->showstates) && $this->showstates == 0) ? ' style="
                     'hasTooltip'
                 ); ?></td>
         </tr>
-        <tr <?php echo $countryStyle; ?>>
+        <tr id="div_state_txt">
             <td valign="top" align="right" class="key">
-                <div id="div_state_lbl" <?php echo $stateStyle; ?>><?php echo JText::_('COM_REDSHOP_STATE'); ?>:</div>
+                <?php echo JText::_('COM_REDSHOP_STATE'); ?>:
             </td>
             <td>
-                <div id="div_state_txt" <?php echo $stateStyle; ?>><?php echo $this->lists['state_code']; ?>
-                    <?php echo JHTML::tooltip(
-                        JText::_('COM_REDSHOP_TOOLTIP_STATE'),
-                        JText::_('COM_REDSHOP_State'),
-                        'tooltip.png',
-                        '',
-                        '',
-                        'hasTooltip'
-                    ); ?></div>
+                <?php echo $this->lists['state_code']; ?>
+                <?php echo JHTML::tooltip(
+                    JText::_('COM_REDSHOP_TOOLTIP_STATE'),
+                    JText::_('COM_REDSHOP_State'),
+                    'tooltip.png',
+                    '',
+                    '',
+                    'hasTooltip'
+                ); ?>
             </td>
         </tr>
+        <script type="text/javascript" language="javascript">
+            if (document.getElementById('rs_state_state_code')) {
+                if (document.getElementById('rs_state_state_code').options[1] == undefined) {
+                    document.getElementById('div_state_txt').style.display = 'none';
+                }
+            }
+        </script>
         <tr>
             <td valign="top" align="right" class="key"><?php echo JText::_('COM_REDSHOP_PHONE'); ?>:</td>
             <td><input class="inputbox" type="text" name="phone" id="phone" size="20"

--- a/component/admin/views/user_detail/tmpl/default_billing.php
+++ b/component/admin/views/user_detail/tmpl/default_billing.php
@@ -25,6 +25,11 @@ $stateStyle   = (isset($this->showstates) && $this->showstates == 0) ? ' style="
 ?>
 <div class="col50">
     <table class="admintable table">
+        <tr id="trCompanyName" <?php echo $allowCompany; ?>>
+            <td valign="top" align="right" class="key"><?php echo JText::_('COM_REDSHOP_COMPANY_NAME'); ?>:</td>
+            <td><input class="text_area" type="text" name="company_name"
+                       value="<?php echo $this->detail->company_name; ?>" size="20" maxlength="250"/></td>
+        </tr>
         <tr>
             <td valign="top" align="right" class="key">
                 <span id="divFirstname"><?php echo JText::_('COM_REDSHOP_FIRST_NAME'); ?></span>:
@@ -56,11 +61,6 @@ $stateStyle   = (isset($this->showstates) && $this->showstates == 0) ? ' style="
                 ); ?>
                 <span id="user_valid">*</span>
             </td>
-        </tr>
-        <tr id="trCompanyName" <?php echo $allowCompany; ?>>
-            <td valign="top" align="right" class="key"><?php echo JText::_('COM_REDSHOP_COMPANY_NAME'); ?>:</td>
-            <td><input class="text_area" type="text" name="company_name"
-                       value="<?php echo $this->detail->company_name; ?>" size="20" maxlength="250"/></td>
         </tr>
         <tr>
             <td valign="top" align="right" class="key"><?php echo JText::_('COM_REDSHOP_ADDRESS'); ?>:</td>


### PR DESCRIPTION
I corrected the display:none functions for when a country does not have states, it didnt work for years.

The function in [redshop.js](https://github.com/redCOMPONENT-COM/redSHOP/blob/develop/media/com_redshop/js/redshop.js) does work and display:none the State TR on change of country. But it does not hide id="div_state_txt" on initial load.

There is a issue in admin Addorder.
If the BT country has states and you add shipping and choose a country that has no states redshop.js function also hides the BT state. I guess this effects only big international shop and happens rarely. Not a issue for me.
My commits has not fixed or created this issue.

@lunguyenhat @NguyenBao10 

