### PR TITLE
Self pick and postnord pickup point tags

### DIFF
--- a/component/admin/views/template/tmpl/edit_hints.php
+++ b/component/admin/views/template/tmpl/edit_hints.php
@@ -68,6 +68,8 @@ $newShippingTags = array(
     'state'                  => '',
     'phone_lbl'              => '',
     'phone'                  => '',
+    'postnord_shop_name'     => '',
+    'self_pickup'            => '',
     'shipping_extrafield'    => '',
     'shipping_address_end'   => ''
 )

--- a/libraries/redshop/src/Shipping/Tag.php
+++ b/libraries/redshop/src/Shipping/Tag.php
@@ -203,7 +203,7 @@ class Tag
         $ShipData      = \Redshop\Shipping\Rate::decrypt($OrderData->ship_method_id);
 
         if (null !== $shippingAddress && $shippingAddress !== new \stdClass && $shippingEnable 
-                && $ShipData[0] !== plgredshop_shippingself_pickup) {
+                && $ShipData[0] !== 'plgredshop_shippingself_pickup') {
             $extraSection = $shippingAddress->is_company == 1 ?
                 \RedshopHelperExtrafields::SECTION_COMPANY_SHIPPING_ADDRESS : \RedshopHelperExtrafields::SECTION_PRIVATE_SHIPPING_ADDRESS;
 
@@ -325,7 +325,7 @@ class Tag
                 $shippingData
             );
         } elseif (null !== $shippingAddress && $shippingAddress !== new \stdClass && $shippingEnable 
-                    && $ShipData[0] == plgredshop_shippingself_pickup) {
+                    && $ShipData[0] == 'plgredshop_shippingself_pickup') {
 			self::replaceTag(
 				$shippingData,
 				$ShipData[2],

--- a/libraries/redshop/src/Shipping/Tag.php
+++ b/libraries/redshop/src/Shipping/Tag.php
@@ -199,11 +199,11 @@ class Tag
         $templateStart = explode('{shipping_address_start}', $templateHtml);
         $templateEnd   = explode('{shipping_address_end}', $templateStart[1]);
         $shippingData  = $shippingEnable ? $templateEnd[0] : '';
-        $OrderData     = \RedshopEntityOrder::getInstance($shippingAddress->order_id);
-        $ShipData      = \Redshop\Shipping\Rate::decrypt($OrderData->ship_method_id);
+        $orderData     = \RedshopEntityOrder::getInstance($shippingAddress->order_id);
+        $shipData      = \Redshop\Shipping\Rate::decrypt($orderData->ship_method_id);
 
         if (null !== $shippingAddress && $shippingAddress !== new \stdClass && $shippingEnable 
-                && $ShipData[0] !== 'plgredshop_shippingself_pickup') {
+                && $shipData[0] !== 'plgredshop_shippingself_pickup') {
             $extraSection = $shippingAddress->is_company == 1 ?
                 \RedshopHelperExtrafields::SECTION_COMPANY_SHIPPING_ADDRESS : \RedshopHelperExtrafields::SECTION_PRIVATE_SHIPPING_ADDRESS;
 
@@ -284,15 +284,14 @@ class Tag
                 array($shippingAddress->phone, \JText::_('COM_REDSHOP_PHONE'))
             );
 
-            $shopId     = \RedshopEntityOrder::getInstance($shippingAddress->order_id);
-            $shopIdTrim = explode("|", $shopId->shop_id);
+            $shopIdTrim = explode("|", $orderData->shop_id);
 			
-            if (!empty($OrderData->shop_id)) {
+            if (!empty($orderData->shop_id)) {
                 self::replaceTag(
                     $shippingData,
                     $shopIdTrim,
                     array('{postnord_shop_name}'),
-                    array('<div style="border-bottom: 1px solid #d5d5d5;">
+                    array('<div style="postnord-name">
                             ' . $shopIdTrim[1] . ' - ' . $shopIdTrim[2] . ' - ' . $shopIdTrim[4] . '</div>')
                 );
             } else {
@@ -306,7 +305,7 @@ class Tag
 
             self::replaceTag(
                 $shippingData,
-                $ShipData[2],
+                $shipData[2],
                 array('{self_pickup}'),
                 array("")
             );
@@ -325,12 +324,12 @@ class Tag
                 $shippingData
             );
         } elseif (null !== $shippingAddress && $shippingAddress !== new \stdClass && $shippingEnable 
-                    && $ShipData[0] == 'plgredshop_shippingself_pickup') {
+                    && $shipData[0] == 'plgredshop_shippingself_pickup') {
             self::replaceTag(
                 $shippingData,
-                $ShipData[2],
+                $shipData[2],
                 array('{self_pickup}'),
-                array($ShipData[2])
+                array($shipData[2])
             );
 
             $shippingData = str_replace(

--- a/libraries/redshop/src/Shipping/Tag.php
+++ b/libraries/redshop/src/Shipping/Tag.php
@@ -304,12 +304,12 @@ class Tag
                 );				
             }
 
-			self::replaceTag(
-				$shippingData,
-				$ShipData[2],
-				array('{self_pickup}'),
-				array("")
-			);
+            self::replaceTag(
+                $shippingData,
+                $ShipData[2],
+                array('{self_pickup}'),
+                array("")
+            );
 
             $shippingData = str_replace(
                 '{shipping_extrafield}',
@@ -326,12 +326,12 @@ class Tag
             );
         } elseif (null !== $shippingAddress && $shippingAddress !== new \stdClass && $shippingEnable 
                     && $ShipData[0] == 'plgredshop_shippingself_pickup') {
-			self::replaceTag(
-				$shippingData,
-				$ShipData[2],
-				array('{self_pickup}'),
-				array($ShipData[2])
-			);
+            self::replaceTag(
+                $shippingData,
+                $ShipData[2],
+                array('{self_pickup}'),
+                array($ShipData[2])
+            );
 
             $shippingData = str_replace(
                 array(
@@ -353,7 +353,7 @@ class Tag
                     '{state_lbl}',
                     '{phone}',
                     '{phone_lbl}',
-					'{postnord_shop_name}',
+                    '{postnord_shop_name}',
                     '{shipping_extrafield}'
                 ),
                 '',

--- a/media/com_redshop/css/redshop.admin.css
+++ b/media/com_redshop/css/redshop.admin.css
@@ -18206,8 +18206,6 @@ Searchtools
 .select2-container {
     width: 100%;
     max-width: 100%;
-    border-radius: 3px;
-    border: 1px solid #ccc;
 }
 
 .select2-container .select2-choice {
@@ -29361,6 +29359,7 @@ body.modal-open {
 
 #redSHOPAdminContainer .select2-container {
     width: 100%;
+    display: block;
 }
 
 .select2-disabled {
@@ -29399,7 +29398,6 @@ body.modal-open {
     background-clip: padding-box;
     outline: none;
 }
-
 #editModal.modal.fade {
     -webkit-transition: opacity .3s linear, top .3s ease-out;
     -moz-transition: opacity .3s linear, top .3s ease-out;
@@ -29407,105 +29405,84 @@ body.modal-open {
     transition: opacity .3s linear, top .3s ease-out;
     top: -25%;
 }
-
 #editModal.modal.fade.in {
     top: 5%;
 }
-
 #editModal.modal-batch {
     overflow-y: visible;
 }
+
 
 .modal-body[class^="jviewport-height"],
 .modal-body[class*="jviewport-height"] {
     max-height: none;
 }
-
 .jviewport-height10 {
     height: 10vh;
 }
-
 .jviewport-height20 {
     height: 20vh;
 }
-
 .jviewport-height30 {
     height: 30vh;
 }
-
 .jviewport-height40 {
     height: 40vh;
 }
-
 .jviewport-height50 {
     height: 50vh;
 }
-
 .jviewport-height60 {
     height: 60vh;
 }
-
 .jviewport-height70 {
     height: 70vh;
 }
-
 .jviewport-height80 {
     height: 80vh;
 }
-
 .jviewport-height90 {
     height: 90vh;
 }
-
 .jviewport-height100 {
     height: 100vh;
 }
-
 div.modal.jviewport-width10 {
     width: 10vw;
     margin-left: -5vw;
 }
-
 div.modal.jviewport-width20 {
     width: 20vw;
     margin-left: -10vw;
 }
-
 div.modal.jviewport-width30 {
     width: 30vw;
     margin-left: -15vw;
 }
-
 div.modal.jviewport-width40 {
     width: 40vw;
     margin-left: -20vw;
 }
-
 div.modal.jviewport-width50 {
     width: 50vw;
     margin-left: -25vw;
 }
-
 div.modal.jviewport-width60 {
     width: 60vw;
     margin-left: -30vw;
 }
-
 div.modal.jviewport-width70 {
     width: 70vw;
     margin-left: -35vw;
 }
-
 div.modal.jviewport-width80 {
     width: 80vw;
     margin-left: -40vw;
 }
-
 div.modal.jviewport-width90 {
     width: 90vw;
     margin-left: -45vw;
 }
-
 div.modal.jviewport-width100 {
     width: 100vw;
     margin-left: -50vw;
@@ -29517,23 +29494,4 @@ div.modal.jviewport-width100 {
 
 .table-striped tbody > tr > td.day.active {
     background-color: #337ab7 !important;
-}
-
-.postnord-name {
-    border-bottom: 1px solid #d5d5d5;
-}
-
-#filter, #filter_from_date, #filter_to_date, #filter_search, #keyword, .js-stools-btn-filter {
-    height: 40px !important;
-}
-
-#search {
-    color: #fff;
-    background-color: #7f7f7f;
-    height: 40px;
-    margin-right: 20px;
-}
-
-.field-calendar {
-    display:inline;
 }

--- a/media/com_redshop/css/redshop.admin.css
+++ b/media/com_redshop/css/redshop.admin.css
@@ -18206,6 +18206,8 @@ Searchtools
 .select2-container {
     width: 100%;
     max-width: 100%;
+    border-radius: 3px;
+    border: 1px solid #ccc;
 }
 
 .select2-container .select2-choice {
@@ -29359,7 +29361,6 @@ body.modal-open {
 
 #redSHOPAdminContainer .select2-container {
     width: 100%;
-    display: block;
 }
 
 .select2-disabled {
@@ -29398,6 +29399,7 @@ body.modal-open {
     background-clip: padding-box;
     outline: none;
 }
+
 #editModal.modal.fade {
     -webkit-transition: opacity .3s linear, top .3s ease-out;
     -moz-transition: opacity .3s linear, top .3s ease-out;
@@ -29405,84 +29407,105 @@ body.modal-open {
     transition: opacity .3s linear, top .3s ease-out;
     top: -25%;
 }
+
 #editModal.modal.fade.in {
     top: 5%;
 }
+
 #editModal.modal-batch {
     overflow-y: visible;
 }
-
 
 .modal-body[class^="jviewport-height"],
 .modal-body[class*="jviewport-height"] {
     max-height: none;
 }
+
 .jviewport-height10 {
     height: 10vh;
 }
+
 .jviewport-height20 {
     height: 20vh;
 }
+
 .jviewport-height30 {
     height: 30vh;
 }
+
 .jviewport-height40 {
     height: 40vh;
 }
+
 .jviewport-height50 {
     height: 50vh;
 }
+
 .jviewport-height60 {
     height: 60vh;
 }
+
 .jviewport-height70 {
     height: 70vh;
 }
+
 .jviewport-height80 {
     height: 80vh;
 }
+
 .jviewport-height90 {
     height: 90vh;
 }
+
 .jviewport-height100 {
     height: 100vh;
 }
+
 div.modal.jviewport-width10 {
     width: 10vw;
     margin-left: -5vw;
 }
+
 div.modal.jviewport-width20 {
     width: 20vw;
     margin-left: -10vw;
 }
+
 div.modal.jviewport-width30 {
     width: 30vw;
     margin-left: -15vw;
 }
+
 div.modal.jviewport-width40 {
     width: 40vw;
     margin-left: -20vw;
 }
+
 div.modal.jviewport-width50 {
     width: 50vw;
     margin-left: -25vw;
 }
+
 div.modal.jviewport-width60 {
     width: 60vw;
     margin-left: -30vw;
 }
+
 div.modal.jviewport-width70 {
     width: 70vw;
     margin-left: -35vw;
 }
+
 div.modal.jviewport-width80 {
     width: 80vw;
     margin-left: -40vw;
 }
+
 div.modal.jviewport-width90 {
     width: 90vw;
     margin-left: -45vw;
 }
+
 div.modal.jviewport-width100 {
     width: 100vw;
     margin-left: -50vw;
@@ -29494,4 +29517,23 @@ div.modal.jviewport-width100 {
 
 .table-striped tbody > tr > td.day.active {
     background-color: #337ab7 !important;
+}
+
+.postnord-name {
+    border-bottom: 1px solid #d5d5d5;
+}
+
+#filter, #filter_from_date, #filter_to_date, #filter_search, #keyword, .js-stools-btn-filter {
+    height: 40px !important;
+}
+
+#search {
+    color: #fff;
+    background-color: #7f7f7f;
+    height: 40px;
+    margin-right: 20px;
+}
+
+.field-calendar {
+    display:inline;
 }


### PR DESCRIPTION
1. When using shipping plugin "PostNord valgfrit udleveringssted" (current plugin name: redshop_shipping / postdanmark).
Then you can now add the tag {postnord_shop_name} to display the pickup point in the templates; Order detail, Order reciept and Mail order - if you use {shipping_address_start} xxx {shipping_address_end}.

Note: Please uninstall "PostDanmark - Update Shipping User Information / redshop_product / postdanmark"
For both the post label is created correct and the shipping info is correct in reciept etc.

2. When shipping is enabled and you have the shipping option "self_pickup" plugin. Then the shipping information in Order detail, Order reciept and Mail order, will be empty. Because the shipping is not the customers address but the webshops address.
Then you can add the tag {self_pickup} between {shipping_address_start} xxx {shipping_address_end}
That will display the name of the self_pickup shop location.

@NguyenBao10   @VanTrieuThanh 